### PR TITLE
Elide parallelism when Cilk keywords are used in const context

### DIFF
--- a/compiler/rustc_const_eval/src/transform/check_consts/check.rs
+++ b/compiler/rustc_const_eval/src/transform/check_consts/check.rs
@@ -924,19 +924,6 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
                 span_bug!(self.span, "`Terminate` terminator outside of cleanup block")
             }
 
-            // FIXME(jhilton): make these real errors and not ICEs.
-            TerminatorKind::Detach { .. } => {
-                span_bug!(self.span, "`Detach` not allowed in const context")
-            }
-
-            TerminatorKind::Reattach { .. } => {
-                span_bug!(self.span, "`Reattach` not allowed in const context")
-            }
-
-            TerminatorKind::Sync { .. } => {
-                span_bug!(self.span, "`Sync` not allowed in const context")
-            }
-
             TerminatorKind::Assert { .. }
             | TerminatorKind::FalseEdge { .. }
             | TerminatorKind::FalseUnwind { .. }
@@ -944,6 +931,9 @@ impl<'tcx> Visitor<'tcx> for Checker<'_, 'tcx> {
             | TerminatorKind::UnwindResume
             | TerminatorKind::Return
             | TerminatorKind::SwitchInt { .. }
+            | TerminatorKind::Detach { .. }
+            | TerminatorKind::Reattach { .. }
+            | TerminatorKind::Sync { .. }
             | TerminatorKind::Unreachable => {}
         }
     }

--- a/tests/ui/cilk/const_cilk_keywords.rs
+++ b/tests/ui/cilk/const_cilk_keywords.rs
@@ -1,0 +1,15 @@
+// Check what happens when using Cilk keywords in a const context.
+// known-bug: unknown
+
+const fn fib(n: usize) -> usize {
+    if n <= 1 {  
+        return n;
+    }
+
+    let x = cilk_spawn { fib(n - 1) };
+    let y = fib(n - 2);
+    cilk_sync;
+    x + y
+}
+
+fn main() {}

--- a/tests/ui/cilk/const_cilk_keywords.stderr
+++ b/tests/ui/cilk/const_cilk_keywords.stderr
@@ -1,0 +1,12 @@
+error[E0381]: used binding `x` is possibly-uninitialized
+  --> $DIR/const_cilk_keywords.rs:9:9
+   |
+LL |     let x = cilk_spawn { fib(n - 1) };
+   |         ^
+   |         |
+   |         `x` used here but it is possibly-uninitialized
+   |         binding declared here but left uninitialized
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0381`.

--- a/tests/ui/cilk/const_cilk_spawn.rs
+++ b/tests/ui/cilk/const_cilk_spawn.rs
@@ -1,0 +1,8 @@
+// Check what happens when using cilk_spawn in a const context.
+// build-pass
+
+const fn f() {
+    cilk_spawn { let x = 3; x };
+}
+
+fn main() {}

--- a/tests/ui/cilk/const_cilk_sync.rs
+++ b/tests/ui/cilk/const_cilk_sync.rs
@@ -1,0 +1,7 @@
+// build-pass
+// Check what happens when using cilk_sync in a const context.
+const fn f() {
+    cilk_sync;
+}
+
+fn main() {}

--- a/tests/ui/cilk/fib_block_recurse.rs
+++ b/tests/ui/cilk/fib_block_recurse.rs
@@ -1,3 +1,7 @@
+// Checks that a simple Cilk program compiles.
+// build-pass
+// known-bug: unknown
+
 fn fib(n: usize) -> usize {
     if n <= 1 {
         return n;
@@ -9,6 +13,4 @@ fn fib(n: usize) -> usize {
     x + y
 }
 
-fn main() {
-
-}
+fn main() {}

--- a/tests/ui/cilk/fib_block_recurse_no_sync.rs
+++ b/tests/ui/cilk/fib_block_recurse_no_sync.rs
@@ -1,3 +1,6 @@
+// Checks that a cilk program without a sync reports an uninitialized variable error.
+// check-fail
+
 fn fib(n: usize) -> usize {
     if n <= 1 {
         return n;


### PR DESCRIPTION
This PR adds tests for Cilk keywords in a const context and removes the internal compiler errors from Cilk keywords in const contexts.