### PR TITLE
Add feature gate for Cilk keywords

### DIFF
--- a/compiler/rustc_ast_passes/src/feature_gate.rs
+++ b/compiler/rustc_ast_passes/src/feature_gate.rs
@@ -562,6 +562,7 @@ pub fn check_crate(krate: &ast::Crate, sess: &Session, features: &Features) {
     gate_all!(generic_const_items, "generic const items are experimental");
     gate_all!(unnamed_fields, "unnamed fields are not yet fully implemented");
     gate_all!(fn_delegation, "functions delegation is not yet fully implemented");
+    gate_all!(cilk, "cilk keywords are experimental");
 
     if !visitor.features.never_patterns {
         if let Some(spans) = spans.get(&sym::never_patterns) {

--- a/compiler/rustc_feature/src/unstable.rs
+++ b/compiler/rustc_feature/src/unstable.rs
@@ -387,6 +387,8 @@ declare_features! (
     (unstable, cfg_version, "1.45.0", Some(64796)),
     /// Allows to use the `#[cfi_encoding = ""]` attribute.
     (unstable, cfi_encoding, "1.71.0", Some(89653)),
+    /// Allows using cilk keywords like cilk_spawn and cilk_sync.
+    (unstable, cilk, "CURRENT_RUSTC_VERSION", None),
     /// Allows `for<...>` on closures and coroutines.
     (unstable, closure_lifetime_binder, "1.64.0", Some(97362)),
     /// Allows `#[track_caller]` on closures and coroutines.

--- a/compiler/rustc_parse/src/parser/expr.rs
+++ b/compiler/rustc_parse/src/parser/expr.rs
@@ -1939,7 +1939,7 @@ impl<'a> Parser<'a> {
     fn parse_expr_cilk_sync(&mut self) -> PResult<'a, P<Expr>> {
         let lo = self.prev_token.span;
         let kind = ExprKind::CilkSync;
-        // FIXME(jhilton): we want to add feature gating to this after we get it to minimally work.
+        self.sess.gated_spans.gate(sym::cilk, lo.to(self.prev_token.span));
         Ok(self.mk_expr(lo.to(self.prev_token.span), kind))
     }
 
@@ -3422,6 +3422,7 @@ impl<'a> Parser<'a> {
             err
         })?;
         let kind = ExprKind::CilkSpawn(body);
+        self.sess.gated_spans.gate(sym::cilk, lo.to(self.prev_token.span));
         Ok(self.mk_expr_with_attrs(lo.to(self.prev_token.span), kind, attrs))
     }
 

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -519,6 +519,7 @@ symbols! {
         cfi,
         cfi_encoding,
         char,
+        cilk,
         client,
         clippy,
         clobber_abi,

--- a/tests/ui/cilk/borrows_dropped_after_sync.rs
+++ b/tests/ui/cilk/borrows_dropped_after_sync.rs
@@ -1,3 +1,4 @@
+#![feature(cilk)]
 // Tests that borrows are not live after the cilk_sync point.
 // build-pass
 

--- a/tests/ui/cilk/borrows_live_before_sync.rs
+++ b/tests/ui/cilk/borrows_live_before_sync.rs
@@ -1,3 +1,4 @@
+#![feature(cilk)]
 // Tests that borrows are still live before a cilk_sync.
 // build-pass
 // known-bug: unknown

--- a/tests/ui/cilk/const_cilk_keywords.rs
+++ b/tests/ui/cilk/const_cilk_keywords.rs
@@ -1,3 +1,4 @@
+#![feature(cilk)]
 // Check what happens when using Cilk keywords in a const context.
 // known-bug: unknown
 

--- a/tests/ui/cilk/const_cilk_keywords.stderr
+++ b/tests/ui/cilk/const_cilk_keywords.stderr
@@ -1,5 +1,5 @@
 error[E0381]: used binding `x` is possibly-uninitialized
-  --> $DIR/const_cilk_keywords.rs:9:9
+  --> $DIR/const_cilk_keywords.rs:10:9
    |
 LL |     let x = cilk_spawn { fib(n - 1) };
    |         ^

--- a/tests/ui/cilk/const_cilk_spawn.rs
+++ b/tests/ui/cilk/const_cilk_spawn.rs
@@ -1,3 +1,4 @@
+#![feature(cilk)]
 // Check what happens when using cilk_spawn in a const context.
 // build-pass
 

--- a/tests/ui/cilk/const_cilk_sync.rs
+++ b/tests/ui/cilk/const_cilk_sync.rs
@@ -1,3 +1,4 @@
+#![feature(cilk)]
 // Check what happens when using cilk_sync in a const context.
 // build-pass
 

--- a/tests/ui/cilk/fib_block_recurse.rs
+++ b/tests/ui/cilk/fib_block_recurse.rs
@@ -1,3 +1,4 @@
+#![feature(cilk)]
 // Checks that a simple Cilk program compiles.
 // known-bug: unknown
 

--- a/tests/ui/cilk/fib_block_recurse.stderr
+++ b/tests/ui/cilk/fib_block_recurse.stderr
@@ -1,5 +1,5 @@
 error[E0381]: used binding `x` is possibly-uninitialized
-  --> $DIR/fib_block_recurse.rs:8:9
+  --> $DIR/fib_block_recurse.rs:9:9
    |
 LL |     let x = cilk_spawn { fib(n - 1) };
    |         ^

--- a/tests/ui/cilk/fib_block_recurse_no_sync.rs
+++ b/tests/ui/cilk/fib_block_recurse_no_sync.rs
@@ -1,3 +1,4 @@
+#![feature(cilk)]
 // Checks that a cilk program without a sync reports an uninitialized variable error.
 // check-fail
 

--- a/tests/ui/cilk/fib_block_recurse_no_sync.stderr
+++ b/tests/ui/cilk/fib_block_recurse_no_sync.stderr
@@ -1,5 +1,5 @@
 error[E0381]: used binding `x` is possibly-uninitialized
-  --> $DIR/fib_block_recurse_no_sync.rs:8:9
+  --> $DIR/fib_block_recurse_no_sync.rs:9:9
    |
 LL |     let x = cilk_spawn { fib(n - 1) };
    |         ^

--- a/tests/ui/cilk/proper_scoping_of_variables_in_spawned_block.rs
+++ b/tests/ui/cilk/proper_scoping_of_variables_in_spawned_block.rs
@@ -1,3 +1,4 @@
+#![feature(cilk)]
 // Tests that when a variable is declared in a spawned block, it's not usable outside that spawned block.
 fn main() {
     let _ = cilk_spawn { let y = 5; y };

--- a/tests/ui/cilk/proper_scoping_of_variables_in_spawned_block.stderr
+++ b/tests/ui/cilk/proper_scoping_of_variables_in_spawned_block.stderr
@@ -1,11 +1,11 @@
 error[E0425]: cannot find value `y` in this scope
-  --> $DIR/proper_scoping_of_variables_in_spawned_block.rs:4:22
+  --> $DIR/proper_scoping_of_variables_in_spawned_block.rs:5:22
    |
 LL |     println!("y={}", y);
    |                      ^
    |
 help: the binding `y` is available in a different scope in the same function
-  --> $DIR/proper_scoping_of_variables_in_spawned_block.rs:3:30
+  --> $DIR/proper_scoping_of_variables_in_spawned_block.rs:4:30
    |
 LL |     let _ = cilk_spawn { let y = 5; y };
    |                              ^

--- a/tests/ui/cilk/require_sync.rs
+++ b/tests/ui/cilk/require_sync.rs
@@ -1,3 +1,4 @@
+#![feature(cilk)]
 // Tests that values used in a spawned block must be Sync since they can be accessed in parallel.
 // build-pass
 // known-bug: unknown

--- a/tests/ui/feature-gates/cilk.rs
+++ b/tests/ui/feature-gates/cilk.rs
@@ -1,0 +1,4 @@
+fn main() {
+    cilk_spawn { 5 }; //~ ERROR cilk keywords are experimental [E0658]
+    cilk_sync; //~ ERROR cilk keywords are experimental [E0658]
+}

--- a/tests/ui/feature-gates/cilk.stderr
+++ b/tests/ui/feature-gates/cilk.stderr
@@ -1,0 +1,21 @@
+error[E0658]: cilk keywords are experimental
+  --> $DIR/cilk.rs:2:16
+   |
+LL |     cilk_spawn { 5 };
+   |                ^^^^^
+   |
+   = help: add `#![feature(cilk)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error[E0658]: cilk keywords are experimental
+  --> $DIR/cilk.rs:3:5
+   |
+LL |     cilk_sync;
+   |     ^^^^^^^^^
+   |
+   = help: add `#![feature(cilk)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 2 previous errors
+
+For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
This PR adds a feature gate for Cilk keywords so that programs using Cilk keywords only compile when the feature "cilk" is enabled.