### PR TITLE
Use descendant_last_locations rather than child_last_locations

### DIFF
--- a/compiler/rustc_mir_dataflow/src/impls/initialized.rs
+++ b/compiler/rustc_mir_dataflow/src/impls/initialized.rs
@@ -426,7 +426,7 @@ impl<'tcx> GenKillAnalysis<'tcx> for MaybeInitializedPlaces<'_, 'tcx> {
             // We skip the locations that don't exist because a task can have children which aren't synced at this point in the dataflow analysis, since
             // they can be successors of this sync. This is because tasks don't end on sync.
             self.task_tree
-                .children_last_locations(task)
+                .descendant_last_locations(task)
                 .filter_map(|last_location| {
                     self.state_at_last_locations.get(&last_location).cloned()
                 })
@@ -563,7 +563,7 @@ impl<'tcx> GenKillAnalysis<'tcx> for MaybeUninitializedPlaces<'_, 'tcx> {
             let task = self.task_tree.expect_task(location);
             // See the comment in `MaybeInitializedPlaces::terminator_effect` for why we skip locations that have no state.
             self.task_tree
-                .children_last_locations(task)
+                .descendant_last_locations(task)
                 .filter_map(|location| self.state_at_last_locations.get(&location))
                 .for_each(|state| {
                     use crate::lattice::MeetSemiLattice;
@@ -843,7 +843,7 @@ impl<'tcx> GenKillAnalysis<'tcx> for EverInitializedPlaces<'_, 'tcx> {
         } else if let mir::TerminatorKind::Sync { target: _ } = terminator.kind {
             let task = self.task_tree.expect_task(location);
             self.task_tree
-                .children_last_locations(task)
+                .descendant_last_locations(task)
                 .filter_map(|location| self.state_at_last_locations.get(&location))
                 .for_each(|state| {
                     // This lattice has all-uninitialized as the bottom and the join operator adds

--- a/compiler/rustc_mir_dataflow/src/mark_cilk_tasks.rs
+++ b/compiler/rustc_mir_dataflow/src/mark_cilk_tasks.rs
@@ -131,9 +131,13 @@ impl TaskTree {
         self.task(location.block).expect("expected block to have a task!")
     }
 
-    /// Get the last locations of the children of this task, panicking if it doesn't exist.
-    pub fn children_last_locations(&self, task: Task) -> impl Iterator<Item = Location> + '_ {
-        self.children(task).flat_map(move |child| self.last_locations(child))
+    /// Get the last locations of any task that is a descendant of this task, panicking if it doesn't exist.
+    ///
+    /// We return a boxed iterator because it's fairly hard to make a recursive iterator.
+    pub fn descendant_last_locations(&self, task: Task) -> Box<dyn Iterator<Item = Location> + '_> {
+        Box::new(self.children(task).flat_map(move |child| {
+            self.last_locations(child).chain(self.descendant_last_locations(child))
+        }))
     }
 
     /// Get the children of this task, panicking if it doesn't exist.

--- a/tests/ui/cilk/sync_nested_tasks.rs
+++ b/tests/ui/cilk/sync_nested_tasks.rs
@@ -1,0 +1,13 @@
+#![feature(cilk)]
+// Tests that when we sync nested tasks, the liveness analysis correctly considers the variables
+// defined in the nested task as live.
+// build-pass
+
+fn f() -> usize {
+    let y;
+    let x = cilk_spawn { cilk_spawn { y = 1 }; 2 };
+    cilk_sync;
+    x + y
+}
+
+fn main() {}


### PR DESCRIPTION
The semantics of cilk_sync are that it syncs any descendants of the current task, not just children. We change the liveness analysis to match that by computing the last locations of any task descending from the current task, not just immediate children.

We do this with a recursive iterator, which I don't love because I'd rather somehow avoid the heap allocation. If it becomes a problem we can fix it.