### PR TITLE
Change parser error to be for keyword

### DIFF
--- a/tests/ui/feature-gates/feature-gate-cilk.stderr
+++ b/tests/ui/feature-gates/feature-gate-cilk.stderr
@@ -1,8 +1,8 @@
 error[E0658]: cilk keywords are experimental
-  --> $DIR/feature-gate-cilk.rs:2:16
+  --> $DIR/feature-gate-cilk.rs:2:5
    |
 LL |     cilk_spawn { 5 };
-   |                ^^^^^
+   |     ^^^^^^^^^^
    |
    = help: add `#![feature(cilk)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date


### PR DESCRIPTION
Change the parser error for how we gate the Cilk feature to focus on the cilk_spawn keyword rather than the spawned expression.

Future work in this direction includes making sure that errors for spawns include the cilk_spawn as well as whatever code is spawned.