### PR TITLE
Implement code generation of Tapir IR

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -40,7 +40,7 @@
 	shallow = true
 [submodule "src/llvm-project"]
 	path = src/llvm-project
-	url = https://github.com/OpenCilk/opencilk-project.git
-    branch = dev/17.x
-    shallow = true
+	url = https://github.com/aleph-oh/opencilk-project.git
+	branch = dev/17.x-darwin-bitcode-multiple-arch
+	shallow = true
 	ignore = dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -30,11 +30,6 @@
 	path = src/doc/edition-guide
 	url = https://github.com/rust-lang/edition-guide.git
 	shallow = true
-[submodule "src/llvm-project"]
-	path = src/llvm-project
-	url = https://github.com/rust-lang/llvm-project.git
-	branch = rustc/18.0-2024-02-13
-	shallow = true
 [submodule "src/doc/embedded-book"]
 	path = src/doc/embedded-book
 	url = https://github.com/rust-embedded/book.git
@@ -43,3 +38,8 @@
 	path = library/backtrace
 	url = https://github.com/rust-lang/backtrace-rs.git
 	shallow = true
+[submodule "src/llvm-project"]
+	path = src/llvm-project
+	url = https://github.com/OpenCilk/opencilk-project.git
+    branch = dev/17.x
+    shallow = true

--- a/.gitmodules
+++ b/.gitmodules
@@ -43,3 +43,4 @@
 	url = https://github.com/OpenCilk/opencilk-project.git
     branch = dev/17.x
     shallow = true
+	ignore = dirty

--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -647,6 +647,8 @@ pub(crate) fn link(
     Ok(modules.remove(0))
 }
 
+// TODO(jhilton): we're going to need to grab the OpenCilk ABI here and link it! 
+
 pub(crate) unsafe fn codegen(
     cgcx: &CodegenContext<LlvmCodegenBackend>,
     dcx: &DiagCtxt,

--- a/compiler/rustc_codegen_llvm/src/back/write.rs
+++ b/compiler/rustc_codegen_llvm/src/back/write.rs
@@ -647,7 +647,7 @@ pub(crate) fn link(
     Ok(modules.remove(0))
 }
 
-// TODO(jhilton): we're going to need to grab the OpenCilk ABI here and link it! 
+// FIXME(jhilton): we may need to manually link the ABI here, but I don't think we should have to b/c of setting TLII in PassWrapper.
 
 pub(crate) unsafe fn codegen(
     cgcx: &CodegenContext<LlvmCodegenBackend>,

--- a/compiler/rustc_codegen_llvm/src/builder.rs
+++ b/compiler/rustc_codegen_llvm/src/builder.rs
@@ -45,6 +45,12 @@ impl Drop for Builder<'_, '_, '_> {
     }
 }
 
+impl MaybeSupportsTapir for Builder<'_, '_, '_> {
+    fn supports_tapir() -> bool {
+        true
+    }
+}
+
 /// Empty string, to be used where LLVM expects an instruction name, indicating
 /// that the instruction is to be left unnamed (i.e. numbered, in textual IR).
 // FIXME(eddyb) pass `&CStr` directly to FFI once it's a thin pointer.
@@ -265,6 +271,29 @@ impl<'a, 'll, 'tcx> BuilderMethods<'a, 'tcx> for Builder<'a, 'll, 'tcx> {
     fn unreachable(&mut self) {
         unsafe {
             llvm::LLVMBuildUnreachable(self.llbuilder);
+        }
+    }
+
+    fn detach(
+        &mut self,
+        task: &'ll BasicBlock,
+        continuation: &'ll BasicBlock,
+        sync_region: &'ll Value,
+    ) {
+        unsafe {
+            llvm::LLVMBuildDetach(self.llbuilder, task, continuation, sync_region);
+        }
+    }
+
+    fn reattach(&mut self, continuation: &'ll BasicBlock, sync_region: &'ll Value) {
+        unsafe {
+            llvm::LLVMBuildReattach(self.llbuilder, continuation, sync_region);
+        }
+    }
+
+    fn sync(&mut self, target: &'ll BasicBlock, sync_region: &'ll Value) {
+        unsafe {
+            llvm::LLVMBuildSync(self.llbuilder, target, sync_region);
         }
     }
 

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -947,6 +947,8 @@ impl<'ll> CodegenCx<'ll, '_> {
 
         ifn!("llvm.ptrmask", fn(ptr, t_isize) -> ptr);
 
+        ifn!("llvm.syncregion.start", fn() -> t_token);
+
         None
     }
 

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -73,6 +73,8 @@ fn get_simple_intrinsic<'ll>(
         sym::ptr_mask => "llvm.ptrmask",
         sym::roundevenf32 => "llvm.roundeven.f32",
         sym::roundevenf64 => "llvm.roundeven.f64",
+        // We need sync regions to generate Tapir IR.
+        sym::sync_region_start => "llvm.syncregion.start",
         _ => return None,
     };
     Some(cx.get_intrinsic(llvm_name))
@@ -449,6 +451,10 @@ impl<'ll, 'tcx> IntrinsicCallMethods<'tcx> for Builder<'_, 'll, 'tcx> {
 
     fn va_end(&mut self, va_list: &'ll Value) -> &'ll Value {
         self.call_intrinsic("llvm.va_end", &[va_list])
+    }
+
+    fn sync_region_start(&mut self) -> Self::Value {
+        self.call_intrinsic("llvm.syncregion.start", &[])
     }
 }
 

--- a/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
+++ b/compiler/rustc_codegen_llvm/src/llvm/ffi.rs
@@ -1063,6 +1063,23 @@ extern "C" {
     ) -> &'a Value;
     pub fn LLVMBuildResume<'a>(B: &Builder<'a>, Exn: &'a Value) -> &'a Value;
     pub fn LLVMBuildUnreachable<'a>(B: &Builder<'a>) -> &'a Value;
+    // Tapir terminators.
+    pub fn LLVMBuildDetach<'a>(
+        B: &Builder<'a>,
+        Task: &'a BasicBlock,
+        Continuation: &'a BasicBlock,
+        SyncRegion: &'a Value,
+    ) -> &'a Value;
+    pub fn LLVMBuildReattach<'a>(
+        B: &Builder<'a>,
+        Continuation: &'a BasicBlock,
+        SyncRegion: &'a Value,
+    ) -> &'a Value;
+    pub fn LLVMBuildSync<'a>(
+        B: &Builder<'a>,
+        Target: &'a BasicBlock,
+        SyncRegion: &'a Value,
+    ) -> &'a Value;
 
     pub fn LLVMBuildCleanupPad<'a>(
         B: &Builder<'a>,

--- a/compiler/rustc_codegen_ssa/src/mir/mod.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/mod.rs
@@ -110,6 +110,13 @@ pub struct FunctionCx<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> {
 
     /// Caller location propagated if this function has `#[track_caller]`.
     caller_location: Option<OperandRef<'tcx, Bx::Value>>,
+
+    /// The sync_region for this function. We expect to only need one sync region for simple
+    /// cases, so we'll not worry about a more complex representation for now. We also don't use
+    /// OperandRef here since sync regions don't have a corresponding Rust type and are fairly
+    /// similar to PhantomData. We do cache the sync region so that the first time it's requested,
+    /// we add a statement to compute the sync region.
+    sync_region: Option<Bx::Value>,
 }
 
 impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
@@ -207,6 +214,7 @@ pub fn codegen_mir<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
         debug_context,
         per_local_var_debug_info: None,
         caller_location: None,
+        sync_region: None,
     };
 
     // It may seem like we should iterate over `required_consts` to ensure they all successfully
@@ -255,6 +263,22 @@ pub fn codegen_mir<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>>(
 
     // Apply debuginfo to the newly allocated locals.
     fx.debug_introduce_locals(&mut start_bx);
+
+    let uses_cilk_control_flow = || {
+        mir.basic_blocks.iter().any(|bb| {
+            matches!(
+                bb.terminator().kind,
+                mir::TerminatorKind::Detach { .. }
+                    | mir::TerminatorKind::Reattach { .. }
+                    | mir::TerminatorKind::Sync { .. }
+            )
+        })
+    };
+
+    if Bx::supports_tapir() && uses_cilk_control_flow() {
+        // Add a sync region at the top of the function, so we can use it later.
+        fx.sync_region = Some(start_bx.sync_region_start());
+    }
 
     // The builders will be created separately for each basic block at `codegen_block`.
     // So drop the builder of `start_llbb` to avoid having two at the same time.

--- a/compiler/rustc_codegen_ssa/src/traits/backend.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/backend.rs
@@ -166,3 +166,8 @@ impl dyn PrintBackendInfo + '_ {
         self.infallible_write_fmt(args);
     }
 }
+
+// FIXME(jhilton): this is better with const generics but we'll get more merge conflicts...
+pub trait MaybeSupportsTapir {
+    fn supports_tapir() -> bool;
+}

--- a/compiler/rustc_codegen_ssa/src/traits/builder.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/builder.rs
@@ -5,7 +5,7 @@ use super::debuginfo::DebugInfoBuilderMethods;
 use super::intrinsic::IntrinsicCallMethods;
 use super::misc::MiscMethods;
 use super::type_::{ArgAbiMethods, BaseTypeMethods};
-use super::{HasCodegen, StaticBuilderMethods};
+use super::{HasCodegen, MaybeSupportsTapir, StaticBuilderMethods};
 
 use crate::common::{
     AtomicOrdering, AtomicRmwBinOp, IntPredicate, RealPredicate, SynchronizationScope, TypeKind,
@@ -40,6 +40,7 @@ pub trait BuilderMethods<'a, 'tcx>:
     + StaticBuilderMethods
     + HasParamEnv<'tcx>
     + HasTargetSpec
+    + MaybeSupportsTapir
 {
     fn build(cx: &'a Self::CodegenCx, llbb: Self::BasicBlock) -> Self;
 
@@ -82,6 +83,14 @@ pub trait BuilderMethods<'a, 'tcx>:
         funclet: Option<&Self::Funclet>,
     ) -> Self::Value;
     fn unreachable(&mut self);
+    fn detach(
+        &mut self,
+        task_llbb: Self::BasicBlock,
+        continuation_llbb: Self::BasicBlock,
+        sync_region: Self::Value,
+    );
+    fn reattach(&mut self, continuation_llbb: Self::BasicBlock, sync_region: Self::Value);
+    fn sync(&mut self, target_llbb: Self::BasicBlock, sync_region: Self::Value);
 
     fn add(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value;
     fn fadd(&mut self, lhs: Self::Value, rhs: Self::Value) -> Self::Value;

--- a/compiler/rustc_codegen_ssa/src/traits/intrinsic.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/intrinsic.rs
@@ -36,4 +36,5 @@ pub trait IntrinsicCallMethods<'tcx>: BackendTypes {
     /// Trait method used to inject `va_end` on the "spoofed" `VaListImpl` before
     /// Rust defined C-variadic functions return.
     fn va_end(&mut self, val: Self::Value) -> Self::Value;
+    fn sync_region_start(&mut self) -> Self::Value;
 }

--- a/compiler/rustc_codegen_ssa/src/traits/mod.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/mod.rs
@@ -31,7 +31,8 @@ mod write;
 pub use self::abi::AbiBuilderMethods;
 pub use self::asm::{AsmBuilderMethods, AsmMethods, GlobalAsmOperandRef, InlineAsmOperandRef};
 pub use self::backend::{
-    Backend, BackendTypes, CodegenBackend, ExtraBackendMethods, PrintBackendInfo,
+    Backend, BackendTypes, CodegenBackend, ExtraBackendMethods, MaybeSupportsTapir,
+    PrintBackendInfo,
 };
 pub use self::builder::{BuilderMethods, OverflowOp};
 pub use self::consts::ConstMethods;

--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -818,6 +818,7 @@ LLVMRustOptimize(
 
   Triple TargetTriple(TheModule->getTargetTriple());
   std::unique_ptr<TargetLibraryInfoImpl> TLII(new TargetLibraryInfoImpl(TargetTriple));
+  // TODO(jhilton): specify OpenCilk ABI path here? I think we only want to do this if there's LTO, but I'm not sure.
   if (DisableSimplifyLibCalls)
     TLII->disableAllFunctions();
   FAM.registerPass([&] { return TargetLibraryAnalysis(*TLII); });

--- a/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
+++ b/compiler/rustc_llvm/llvm-wrapper/PassWrapper.cpp
@@ -532,14 +532,24 @@ extern "C" void LLVMRustDisposeTargetMachine(LLVMTargetMachineRef TM) {
   delete unwrap(TM);
 }
 
-// FIXME(jhilton): don't hardcode this!
-const StringRef OPENCILK_ABI_PATH =
-    "/Users/jay/Code/MEng/opencilk/build/lib/clang/17/lib/darwin/libopencilk-abi_osx.bc";
+// Read the environment variable OPENCILK_ABI_PATH to get the path to the OpenCilk ABI for
+// this target.
+// FIXME(jhilton): we should detect this for the given architecture and search in specified directories
+// instead.
+StringRef FindOpenCilkABIBitCodeFilePath()
+{
+  const char *ABIPath = getenv("OPENCILK_ABI_PATH");
+  if (!ABIPath)
+  {
+    report_fatal_error("OPENCILK_ABI_PATH environment variable not set");
+  }
+  return ABIPath;
+}
 
 void addTapirOptions(TargetLibraryInfoImpl &TLII)
 {
   TLII.setTapirTarget(TapirTargetID::OpenCilk);
-  TLII.setTapirTargetOptions(std::make_unique<OpenCilkABIOptions>(OPENCILK_ABI_PATH));
+  TLII.setTapirTargetOptions(std::make_unique<OpenCilkABIOptions>(FindOpenCilkABIBitCodeFilePath()));
 }
 
 // Unfortunately, the LLVM C API doesn't provide a way to create the

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1637,6 +1637,7 @@ symbols! {
         suggestion,
         sym,
         sync,
+        sync_region_start,
         t32,
         target,
         target_abi,

--- a/compiler/rustc_target/src/spec/targets/aarch64_apple_darwin.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_apple_darwin.rs
@@ -16,6 +16,7 @@ pub fn target() -> Target {
         "-L".into(),
         "/Users/jay/Code/MEng/opencilk/build/lib/clang/17/lib/darwin".into(),
         "-lopencilk_osx_dynamic".into(),
+        "-Wl,-rpath,/Users/jay/Code/MEng/opencilk/build/lib/clang/17/lib/darwin".into(),
     ];
     late_link_args.insert(LinkerFlavor::Darwin(Cc::Yes, Lld::No), args_to_link_opencilk.clone());
     Target {

--- a/compiler/rustc_target/src/spec/targets/aarch64_apple_darwin.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_apple_darwin.rs
@@ -1,5 +1,5 @@
 use crate::spec::base::apple::{macos_llvm_target, opts, Arch};
-use crate::spec::{FramePointer, SanitizerSet, Target, TargetOptions};
+use crate::spec::{Cc, FramePointer, LinkerFlavor, Lld, SanitizerSet, Target, TargetOptions};
 
 pub fn target() -> Target {
     let arch = Arch::Arm64;
@@ -10,6 +10,14 @@ pub fn target() -> Target {
     // FIXME: The leak sanitizer currently fails the tests, see #88132.
     base.supported_sanitizers = SanitizerSet::ADDRESS | SanitizerSet::CFI | SanitizerSet::THREAD;
 
+    let mut late_link_args = std::collections::BTreeMap::new();
+    // FIXME(jhilton): this path should reference something inside the build directory at some point
+    let args_to_link_opencilk: Vec<std::borrow::Cow<'static, str>> = vec![
+        "-L".into(),
+        "/Users/jay/Code/MEng/opencilk/build/lib/clang/17/lib/darwin".into(),
+        "-lopencilk_osx_dynamic".into(),
+    ];
+    late_link_args.insert(LinkerFlavor::Darwin(Cc::Yes, Lld::No), args_to_link_opencilk.clone());
     Target {
         // Clang automatically chooses a more specific target based on
         // MACOSX_DEPLOYMENT_TARGET. To enable cross-language LTO to work
@@ -21,6 +29,7 @@ pub fn target() -> Target {
         options: TargetOptions {
             mcount: "\u{1}mcount".into(),
             frame_pointer: FramePointer::NonLeaf,
+            late_link_args,
             ..base
         },
     }

--- a/src/bootstrap/Cargo.lock
+++ b/src/bootstrap/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,6 +61,7 @@ dependencies = [
  "cmake",
  "fd-lock",
  "filetime",
+ "flate2",
  "home",
  "ignore",
  "junction",
@@ -180,6 +187,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,6 +289,16 @@ dependencies = [
  "libc",
  "redox_syscall",
  "windows-sys",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -379,6 +405,15 @@ name = "memchr"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "ntapi"

--- a/src/bootstrap/Cargo.toml
+++ b/src/bootstrap/Cargo.toml
@@ -65,6 +65,7 @@ xz2 = "0.1"
 
 # Dependencies needed by the build-metrics feature
 sysinfo = { version = "0.30", optional = true }
+flate2 = "1.0.28"
 
 [target.'cfg(windows)'.dependencies.junction]
 version = "1.0.0"

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -423,7 +423,8 @@ impl Step for Llvm {
             cfg.define("LLVM_BUILD_32_BITS", "ON");
         }
 
-        // TODO(jhilton): we should also build the OpenCilk runtime.
+        // We also want to build the cheetah and cilktools runtimes to get the right ABI files.
+        cfg.define("LLVM_ENABLE_RUNTIMES", "cheetah;cilktools");
 
         let mut enabled_llvm_projects = Vec::new();
 

--- a/src/bootstrap/src/core/build_steps/llvm.rs
+++ b/src/bootstrap/src/core/build_steps/llvm.rs
@@ -78,6 +78,9 @@ pub fn prebuilt_llvm_config(
 ) -> Result<LlvmResult, Meta> {
     builder.config.maybe_download_ci_llvm();
 
+    builder.config.maybe_download_opencilk_runtime();
+    builder.config.maybe_download_cilktools();
+
     // If we're using a custom LLVM bail out here, but we can only use a
     // custom LLVM for the build triple.
     if let Some(config) = builder.config.target_config.get(&target) {
@@ -419,6 +422,8 @@ impl Step for Llvm {
         if target.starts_with("i686") {
             cfg.define("LLVM_BUILD_32_BITS", "ON");
         }
+
+        // TODO(jhilton): we should also build the OpenCilk runtime.
 
         let mut enabled_llvm_projects = Vec::new();
 

--- a/src/bootstrap/src/core/config/config.rs
+++ b/src/bootstrap/src/core/config/config.rs
@@ -1750,7 +1750,13 @@ impl Config {
             config.llvm_use_linker = use_linker.clone();
             config.llvm_allow_old_toolchain = allow_old_toolchain.unwrap_or(false);
             config.llvm_polly = polly.unwrap_or(false);
-            config.llvm_clang = clang.unwrap_or(false);
+            // We always want to build Clang, regardless of where our LLVM came from. This is because we'll
+            // always need to build Clang to build the runtimes and cilktools, and our default LLVM will now
+            // include that.
+            // HACK(jhilton): this doesn't really make sense unless the targeted LLVM is the same LLVM as the
+            // ony we bootstrap with, so if that assumption is ever not true, then we may want to build without
+            // clang.
+            config.llvm_clang = true;
             config.llvm_enable_warnings = enable_warnings.unwrap_or(false);
             config.llvm_build_config = build_config.clone().unwrap_or(Default::default());
 

--- a/src/bootstrap/src/core/download.rs
+++ b/src/bootstrap/src/core/download.rs
@@ -194,7 +194,13 @@ impl Config {
         let _ = try_run(self, patchelf.arg(fname));
     }
 
-    fn download_file(&self, url: &str, dest_path: &Path, help_on_error: &str) {
+    fn download_file(
+        &self,
+        url: &str,
+        dest_path: &Path,
+        help_on_error: &str,
+        follow_redirects: bool,
+    ) {
         self.verbose(&format!("download {url}"));
         // Use a temporary file in case we crash while downloading, to avoid a corrupt download in cache/.
         let tempfile = self.tempdir().join(dest_path.file_name().unwrap());
@@ -203,7 +209,7 @@ impl Config {
         // protocols without worrying about merge conflicts if we change the HTTP implementation.
         match url.split_once("://").map(|(proto, _)| proto) {
             Some("http") | Some("https") => {
-                self.download_http_with_retries(&tempfile, url, help_on_error)
+                self.download_http_with_retries(&tempfile, url, help_on_error, follow_redirects)
             }
             Some(other) => panic!("unsupported protocol {other} in {url}"),
             None => panic!("no protocol in {url}"),
@@ -214,7 +220,13 @@ impl Config {
         );
     }
 
-    fn download_http_with_retries(&self, tempfile: &Path, url: &str, help_on_error: &str) {
+    fn download_http_with_retries(
+        &self,
+        tempfile: &Path,
+        url: &str,
+        help_on_error: &str,
+        follow_redirects: bool,
+    ) {
         println!("downloading {url}");
         // Try curl. If that fails and we are on windows, fallback to PowerShell.
         let mut curl = Command::new("curl");
@@ -236,6 +248,9 @@ impl Config {
             curl.arg("-s");
         } else {
             curl.arg("--progress-bar");
+        }
+        if follow_redirects {
+            curl.arg("-L");
         }
         curl.arg(url);
         if !self.check_run(&mut curl) {
@@ -263,7 +278,32 @@ impl Config {
         }
     }
 
-    fn unpack(&self, tarball: &Path, dst: &Path, pattern: &str) {
+    fn unpack_gzip(&self, tarball: &Path, dst: &Path, prefix: &Path) {
+        eprintln!("gzip: extracting {} to {}", tarball.display(), dst.display());
+        if !dst.exists() {
+            t!(fs::create_dir_all(dst));
+        }
+
+        // decompress the file
+        let data = t!(File::open(tarball), format!("file {} not found", tarball.display()));
+        let decompressor = flate2::bufread::GzDecoder::new(BufReader::new(data));
+
+        let mut tar = tar::Archive::new(decompressor);
+
+        let entries = t!(tar.entries());
+        entries.filter_map(|e| e.ok()).for_each(|mut entry| {
+            let entry_path = t!(entry.path());
+            if !entry_path.starts_with(prefix) {
+                return;
+            }
+
+            let path = entry_path.strip_prefix(prefix).unwrap().to_owned();
+            let dst = dst.join(&path);
+            t!(entry.unpack(dst));
+        })
+    }
+
+    fn unpack_xz(&self, tarball: &Path, dst: &Path, pattern: &str) {
         eprintln!("extracting {} to {}", tarball.display(), dst.display());
         if !dst.exists() {
             t!(fs::create_dir_all(dst));
@@ -619,7 +659,7 @@ impl Config {
             let sha256 = self.stage0_metadata.checksums_sha256.get(&url).expect(&error);
             if tarball.exists() {
                 if self.verify(&tarball, sha256) {
-                    self.unpack(&tarball, &bin_root, prefix);
+                    self.unpack_xz(&tarball, &bin_root, prefix);
                     return;
                 } else {
                     self.verbose(&format!(
@@ -631,7 +671,7 @@ impl Config {
             }
             Some(sha256)
         } else if tarball.exists() {
-            self.unpack(&tarball, &bin_root, prefix);
+            self.unpack_xz(&tarball, &bin_root, prefix);
             return;
         } else {
             None
@@ -648,14 +688,14 @@ HELP: if trying to compile an old commit of rustc, disable `download-rustc` in c
 download-rustc = false
 ";
         }
-        self.download_file(&format!("{base_url}/{url}"), &tarball, help_on_error);
+        self.download_file(&format!("{base_url}/{url}"), &tarball, help_on_error, false);
         if let Some(sha256) = checksum {
             if !self.verify(&tarball, sha256) {
                 panic!("failed to verify {}", tarball.display());
             }
         }
 
-        self.unpack(&tarball, &bin_root, prefix);
+        self.unpack_xz(&tarball, &bin_root, prefix);
     }
 
     pub(crate) fn maybe_download_ci_llvm(&self) {
@@ -728,9 +768,63 @@ download-rustc = false
     [llvm]
     download-ci-llvm = false
     ";
-            self.download_file(&format!("{base}/{llvm_sha}/{filename}"), &tarball, help_on_error);
+            self.download_file(
+                &format!("{base}/{llvm_sha}/{filename}"),
+                &tarball,
+                help_on_error,
+                false,
+            );
         }
         let llvm_root = self.ci_llvm_root();
-        self.unpack(&tarball, &llvm_root, "rust-dev");
+        self.unpack_xz(&tarball, &llvm_root, "rust-dev");
+    }
+
+    // FIXME(jhilton): I think we shouldn't care about this as long as our runtime file detection is relative to llvm-config.
+    // In that case, we still don't redownload to avoid the extra download. Update the docs when runtime file detection is fixed.
+    // Alternatively, we might not need these methods because if it's already in the cache, we're only saving the time to
+    // unpack the tarballs.
+
+    pub(crate) fn maybe_download_opencilk_runtime(&self) {
+        let url = "https://github.com/OpenCilk/cheetah/archive/dev/17.x.tar.gz";
+        let destination = Path::new("src/llvm-project/cheetah");
+        self.maybe_download_opencilk_component(url, destination, Path::new("cheetah-dev"));
+    }
+
+    pub(crate) fn maybe_download_cilktools(&self) {
+        let url = "https://github.com/OpenCilk/productivity-tools/archive/dev/17.x.tar.gz";
+        let destination = Path::new("src/llvm-project/cilktools");
+        self.maybe_download_opencilk_component(
+            url,
+            destination,
+            Path::new("productivity-tools-dev"),
+        );
+    }
+
+    fn maybe_download_opencilk_component(&self, url: &str, destination: &Path, prefix: &Path) {
+        if destination.exists() {
+            return;
+        }
+
+        self.download_opencilk_component(url, destination, prefix);
+    }
+
+    fn download_opencilk_component(&self, url: &str, destination: &Path, prefix: &Path) {
+        if self.dry_run() {
+            return;
+        }
+
+        let file_name = destination.file_name().unwrap();
+        let cache_prefix = format!("opencilk");
+        let cache_dst = self.out.join("cache");
+        let rustc_cache = cache_dst.join(cache_prefix);
+        if !rustc_cache.exists() {
+            t!(fs::create_dir_all(&rustc_cache));
+        }
+        let tarball = rustc_cache.join(&file_name);
+        if !tarball.exists() {
+            self.download_file(url, &tarball, "", true);
+        }
+        // Now the component is at tarball, we have to unpack it into the destination.
+        self.unpack_gzip(&tarball, &destination, prefix);
     }
 }

--- a/src/bootstrap/src/core/download.rs
+++ b/src/bootstrap/src/core/download.rs
@@ -785,9 +785,14 @@ download-rustc = false
     // unpack the tarballs.
 
     pub(crate) fn maybe_download_opencilk_runtime(&self) {
-        let url = "https://github.com/OpenCilk/cheetah/archive/dev/17.x.tar.gz";
+        let url =
+            "https://github.com/aleph-oh/cheetah-1/archive/dev-darwin-bitcode-multiple-arch.tar.gz";
         let destination = Path::new("src/llvm-project/cheetah");
-        self.maybe_download_opencilk_component(url, destination, Path::new("cheetah-dev"));
+        self.maybe_download_opencilk_component(
+            url,
+            destination,
+            Path::new("cheetah-1-dev-darwin-bitcode-multiple-arch"),
+        );
     }
 
     pub(crate) fn maybe_download_cilktools(&self) {

--- a/tests/ui/cilk/borrows_dropped_after_sync.rs
+++ b/tests/ui/cilk/borrows_dropped_after_sync.rs
@@ -1,7 +1,9 @@
 #![feature(cilk)]
 // Tests that borrows are not live after the cilk_sync point.
-// build-pass
-// compile-flags: -C panic=abort
+
+//@ build-pass
+//@ compile-flags: -C panic=abort
+//@ no-prefer-dynamic
 
 // Note that this test can pass if the borrow is dropped at the end of the block being spawned
 // rather than at the sync. There's another test that borrows are live before a sync.

--- a/tests/ui/cilk/borrows_dropped_after_sync.rs
+++ b/tests/ui/cilk/borrows_dropped_after_sync.rs
@@ -1,9 +1,9 @@
 #![feature(cilk)]
 // Tests that borrows are not live after the cilk_sync point.
 
-//@ build-pass
-//@ compile-flags: -C panic=abort
-//@ no-prefer-dynamic
+// build-pass
+// compile-flags: -C panic=abort
+// no-prefer-dynamic
 
 // Note that this test can pass if the borrow is dropped at the end of the block being spawned
 // rather than at the sync. There's another test that borrows are live before a sync.

--- a/tests/ui/cilk/borrows_dropped_after_sync.rs
+++ b/tests/ui/cilk/borrows_dropped_after_sync.rs
@@ -1,6 +1,7 @@
 #![feature(cilk)]
 // Tests that borrows are not live after the cilk_sync point.
 // build-pass
+// compile-flags: -C panic=abort
 
 // Note that this test can pass if the borrow is dropped at the end of the block being spawned
 // rather than at the sync. There's another test that borrows are live before a sync.

--- a/tests/ui/cilk/borrows_live_before_sync.rs
+++ b/tests/ui/cilk/borrows_live_before_sync.rs
@@ -1,8 +1,10 @@
 #![feature(cilk)]
 // Tests that borrows are still live before a cilk_sync.
-// build-pass
-// known-bug: unknown
-// compile-flags: -C panic=abort
+
+//@ known-bug: unknown
+//@ build-pass
+//@ compile-flags: -C panic=abort
+//@ no-prefer-dynamic
 
 // This should be rejected since s is still referenced by the spawned block
 // and there's no sync to indicate that the borrow can be dropped.

--- a/tests/ui/cilk/borrows_live_before_sync.rs
+++ b/tests/ui/cilk/borrows_live_before_sync.rs
@@ -2,6 +2,7 @@
 // Tests that borrows are still live before a cilk_sync.
 // build-pass
 // known-bug: unknown
+// compile-flags: -C panic=abort
 
 // This should be rejected since s is still referenced by the spawned block
 // and there's no sync to indicate that the borrow can be dropped.

--- a/tests/ui/cilk/borrows_live_before_sync.rs
+++ b/tests/ui/cilk/borrows_live_before_sync.rs
@@ -1,10 +1,10 @@
 #![feature(cilk)]
 // Tests that borrows are still live before a cilk_sync.
 
-//@ known-bug: unknown
-//@ build-pass
-//@ compile-flags: -C panic=abort
-//@ no-prefer-dynamic
+// known-bug: unknown
+// build-pass
+// compile-flags: -C panic=abort
+// no-prefer-dynamic
 
 // This should be rejected since s is still referenced by the spawned block
 // and there's no sync to indicate that the borrow can be dropped.

--- a/tests/ui/cilk/const_cilk_keywords.rs
+++ b/tests/ui/cilk/const_cilk_keywords.rs
@@ -1,6 +1,7 @@
 #![feature(cilk)]
 // Check what happens when using Cilk keywords in a const context.
 // build-pass
+// compile-flags: -C panic=abort
 
 const fn fib(n: usize) -> usize {
     if n <= 1 {

--- a/tests/ui/cilk/const_cilk_keywords.rs
+++ b/tests/ui/cilk/const_cilk_keywords.rs
@@ -1,7 +1,9 @@
 #![feature(cilk)]
 // Check what happens when using Cilk keywords in a const context.
-// build-pass
-// compile-flags: -C panic=abort
+
+//@ build-pass
+//@ compile-flags: -C panic=abort
+//@ no-prefer-dynamic
 
 const fn fib(n: usize) -> usize {
     if n <= 1 {

--- a/tests/ui/cilk/const_cilk_keywords.rs
+++ b/tests/ui/cilk/const_cilk_keywords.rs
@@ -1,9 +1,9 @@
 #![feature(cilk)]
 // Check what happens when using Cilk keywords in a const context.
 
-//@ build-pass
-//@ compile-flags: -C panic=abort
-//@ no-prefer-dynamic
+// build-pass
+// compile-flags: -C panic=abort
+// no-prefer-dynamic
 
 const fn fib(n: usize) -> usize {
     if n <= 1 {

--- a/tests/ui/cilk/const_cilk_keywords.rs
+++ b/tests/ui/cilk/const_cilk_keywords.rs
@@ -1,7 +1,7 @@
 #![feature(cilk)]
 // Check what happens when using Cilk keywords in a const context.
 
-// build-pass
+// run-pass
 // compile-flags: -C panic=abort
 // no-prefer-dynamic
 
@@ -16,4 +16,8 @@ const fn fib(n: usize) -> usize {
     x + y
 }
 
-fn main() {}
+fn main() {
+    let n = 10;
+    let result = fib(n);
+    assert_eq!(result, 55);
+}

--- a/tests/ui/cilk/const_cilk_spawn.rs
+++ b/tests/ui/cilk/const_cilk_spawn.rs
@@ -1,9 +1,9 @@
 #![feature(cilk)]
 // Check what happens when using cilk_spawn in a const context.
 
-//@ build-pass
-//@ compile-flags: -C panic=abort
-//@ no-prefer-dynamic
+// build-pass
+// compile-flags: -C panic=abort
+// no-prefer-dynamic
 
 const fn f() {
     cilk_spawn { let x = 3; x };

--- a/tests/ui/cilk/const_cilk_spawn.rs
+++ b/tests/ui/cilk/const_cilk_spawn.rs
@@ -1,12 +1,14 @@
 #![feature(cilk)]
 // Check what happens when using cilk_spawn in a const context.
 
-// build-pass
+// run-pass
 // compile-flags: -C panic=abort
 // no-prefer-dynamic
 
-const fn f() {
-    cilk_spawn { let x = 3; x };
+const fn f() -> usize {
+    cilk_spawn { let x = 3; x }
 }
 
-fn main() {}
+fn main() {
+    assert_eq!(f(), 3);
+}

--- a/tests/ui/cilk/const_cilk_spawn.rs
+++ b/tests/ui/cilk/const_cilk_spawn.rs
@@ -1,6 +1,7 @@
 #![feature(cilk)]
 // Check what happens when using cilk_spawn in a const context.
 // build-pass
+// compile-flags: -C panic=abort
 
 const fn f() {
     cilk_spawn { let x = 3; x };

--- a/tests/ui/cilk/const_cilk_spawn.rs
+++ b/tests/ui/cilk/const_cilk_spawn.rs
@@ -1,7 +1,9 @@
 #![feature(cilk)]
 // Check what happens when using cilk_spawn in a const context.
-// build-pass
-// compile-flags: -C panic=abort
+
+//@ build-pass
+//@ compile-flags: -C panic=abort
+//@ no-prefer-dynamic
 
 const fn f() {
     cilk_spawn { let x = 3; x };

--- a/tests/ui/cilk/const_cilk_sync.rs
+++ b/tests/ui/cilk/const_cilk_sync.rs
@@ -1,8 +1,8 @@
 #![feature(cilk)]
 // Check what happens when using cilk_sync in a const context.
-//@ build-pass
-//@ compile-flags: -C panic=abort
-//@ no-prefer-dynamic
+// build-pass
+// compile-flags: -C panic=abort
+// no-prefer-dynamic
 
 const fn f() {
     cilk_sync;

--- a/tests/ui/cilk/const_cilk_sync.rs
+++ b/tests/ui/cilk/const_cilk_sync.rs
@@ -1,6 +1,7 @@
 #![feature(cilk)]
 // Check what happens when using cilk_sync in a const context.
 // build-pass
+// compile-flags: -C panic=abort
 
 const fn f() {
     cilk_sync;

--- a/tests/ui/cilk/const_cilk_sync.rs
+++ b/tests/ui/cilk/const_cilk_sync.rs
@@ -1,7 +1,8 @@
 #![feature(cilk)]
 // Check what happens when using cilk_sync in a const context.
-// build-pass
-// compile-flags: -C panic=abort
+//@ build-pass
+//@ compile-flags: -C panic=abort
+//@ no-prefer-dynamic
 
 const fn f() {
     cilk_sync;

--- a/tests/ui/cilk/fib_block_recurse.rs
+++ b/tests/ui/cilk/fib_block_recurse.rs
@@ -1,6 +1,9 @@
 #![feature(cilk)]
 // Checks that a simple Cilk program compiles.
-// build-pass
+
+// run-pass
+// compile-flags: -C panic=abort
+// no-prefer-dynamic
 
 fn fib(n: usize) -> usize {
     if n <= 1 {
@@ -12,4 +15,8 @@ fn fib(n: usize) -> usize {
     x + y
 }
 
-fn main() {}
+fn main() {
+    let n = 10;
+    let result = fib(n);
+    assert_eq!(result, 55);
+}

--- a/tests/ui/cilk/fib_block_recurse_optimized.rs
+++ b/tests/ui/cilk/fib_block_recurse_optimized.rs
@@ -1,0 +1,22 @@
+#![feature(cilk)]
+// Checks that a simple Cilk program compiles.
+
+// run-pass
+// compile-flags: -C panic=abort -O
+// no-prefer-dynamic
+
+fn fib(n: usize) -> usize {
+    if n <= 1 {
+        return n;
+    }
+    let x = cilk_spawn { fib(n - 1) };
+    let y = fib(n - 2);
+    cilk_sync;
+    x + y
+}
+
+fn main() {
+    let n = 10;
+    let result = fib(n);
+    assert_eq!(result, 55);
+}

--- a/tests/ui/cilk/fib_block_recurse_type_ascription.rs
+++ b/tests/ui/cilk/fib_block_recurse_type_ascription.rs
@@ -1,6 +1,7 @@
 #![feature(cilk)]
 // Checks that a simple Cilk program compiles, with type ascription.
 // build-pass
+// compile-flags: -C panic=abort
 
 fn fib(n: usize) -> usize {
     if n <= 1 {

--- a/tests/ui/cilk/fib_block_recurse_type_ascription.rs
+++ b/tests/ui/cilk/fib_block_recurse_type_ascription.rs
@@ -1,7 +1,7 @@
 #![feature(cilk)]
 // Checks that a simple Cilk program compiles, with type ascription.
 
-// build-pass
+// run-pass
 // compile-flags: -C panic=abort
 // no-prefer-dynamic
 
@@ -15,4 +15,8 @@ fn fib(n: usize) -> usize {
     x + y
 }
 
-fn main() {}
+fn main() {
+    let n = 10;
+    let result = fib(n);
+    assert_eq!(result, 55);
+}

--- a/tests/ui/cilk/fib_block_recurse_type_ascription.rs
+++ b/tests/ui/cilk/fib_block_recurse_type_ascription.rs
@@ -1,7 +1,9 @@
 #![feature(cilk)]
 // Checks that a simple Cilk program compiles, with type ascription.
-// build-pass
-// compile-flags: -C panic=abort
+
+//@ build-pass
+//@ compile-flags: -C panic=abort
+//@ no-prefer-dynamic
 
 fn fib(n: usize) -> usize {
     if n <= 1 {

--- a/tests/ui/cilk/fib_block_recurse_type_ascription.rs
+++ b/tests/ui/cilk/fib_block_recurse_type_ascription.rs
@@ -1,9 +1,9 @@
 #![feature(cilk)]
 // Checks that a simple Cilk program compiles, with type ascription.
 
-//@ build-pass
-//@ compile-flags: -C panic=abort
-//@ no-prefer-dynamic
+// build-pass
+// compile-flags: -C panic=abort
+// no-prefer-dynamic
 
 fn fib(n: usize) -> usize {
     if n <= 1 {

--- a/tests/ui/cilk/require_sync.rs
+++ b/tests/ui/cilk/require_sync.rs
@@ -2,9 +2,9 @@
 // Tests that values used in a spawned block must be Sync since they can be accessed in parallel.
 
 // known-bug: unknown
-//@ build-pass
-//@ compile-flags: -C panic=abort
-//@ no-prefer-dynamic
+// build-pass
+// compile-flags: -C panic=abort
+// no-prefer-dynamic
 
 use std::cell::RefCell;
 use std::rc::Rc;

--- a/tests/ui/cilk/require_sync.rs
+++ b/tests/ui/cilk/require_sync.rs
@@ -1,8 +1,10 @@
 #![feature(cilk)]
 // Tests that values used in a spawned block must be Sync since they can be accessed in parallel.
-// build-pass
+
 // known-bug: unknown
-// compile-flags: -C panic=abort
+//@ build-pass
+//@ compile-flags: -C panic=abort
+//@ no-prefer-dynamic
 
 use std::cell::RefCell;
 use std::rc::Rc;

--- a/tests/ui/cilk/require_sync.rs
+++ b/tests/ui/cilk/require_sync.rs
@@ -2,6 +2,8 @@
 // Tests that values used in a spawned block must be Sync since they can be accessed in parallel.
 // build-pass
 // known-bug: unknown
+// compile-flags: -C panic=abort
+
 use std::cell::RefCell;
 use std::rc::Rc;
 

--- a/tests/ui/cilk/sync_nested_tasks.rs
+++ b/tests/ui/cilk/sync_nested_tasks.rs
@@ -2,9 +2,9 @@
 // Tests that when we sync nested tasks, the liveness analysis correctly considers the variables
 // defined in the nested task as live.
 
-//@ build-pass
-//@ compile-flags: -C panic=abort
-//@ no-prefer-dynamic
+// build-pass
+// compile-flags: -C panic=abort
+// no-prefer-dynamic
 
 fn f() -> usize {
     let y;

--- a/tests/ui/cilk/sync_nested_tasks.rs
+++ b/tests/ui/cilk/sync_nested_tasks.rs
@@ -2,6 +2,7 @@
 // Tests that when we sync nested tasks, the liveness analysis correctly considers the variables
 // defined in the nested task as live.
 // build-pass
+// compile-flags: -C panic=abort
 
 fn f() -> usize {
     let y;

--- a/tests/ui/cilk/sync_nested_tasks.rs
+++ b/tests/ui/cilk/sync_nested_tasks.rs
@@ -1,8 +1,10 @@
 #![feature(cilk)]
 // Tests that when we sync nested tasks, the liveness analysis correctly considers the variables
 // defined in the nested task as live.
-// build-pass
-// compile-flags: -C panic=abort
+
+//@ build-pass
+//@ compile-flags: -C panic=abort
+//@ no-prefer-dynamic
 
 fn f() -> usize {
     let y;


### PR DESCRIPTION
This PR generates Tapir IR from programs that use Cilk keywords. It does this by requiring code generation backends indicate whether they support Tapir and implement code generation for the analogous MIR constructs. The LLVM backend is the only one which currently indicates that it provides Tapir support, and it additionally modifies the code generation process to link in the OpenCilk runtime's bitcode files. We also download the OpenCilk runtime and productivity-tools during bootstrapping so that the default compiler supports using Cilk constructs at runtime, which required some changes to the bootstrapping process. 

There are a few limitations at the moment:
- unwind handling is not supported: code must be compiled with panic=abort
- functions must have at most 1 sync region
- sync region tokens are not special-cased, so their naming is not immediately clear (OpenCilk/Clang handles this better)
- the path to the OpenCilk runtime bitcode files that are linked in is provided through an environment variable OPENCILK_ABI_PATH
- the path to the OpenCilk runtime search directory is provided through an environment variable OPENCILK_RT_SEARCH_DIR

This PR also changes the test suite by compiling Cilk tests with panic=abort and statically linking the standard library (which has to be rebuilt since it's typically built with the unwinding panic runtime). Building with LTO also could be better tested: it's possible that when building with LTO we don't properly link the runtime.