### PR TITLE
Implement automatic sync insertion

### DIFF
--- a/compiler/rustc_mir_transform/src/automatic_sync_insertion.rs
+++ b/compiler/rustc_mir_transform/src/automatic_sync_insertion.rs
@@ -1,0 +1,50 @@
+/// This pass inserts a sync before every return terminator in a function that contains a detach.
+/// We need this to have the correct behavior: we need to make sure that functions with detaches
+/// always end with only a single task.
+use rustc_middle::mir::{self, MirPass};
+use rustc_middle::ty::TyCtxt;
+
+/// Returns true if the given body contains a detach, which implies that there should be a sync before the return.
+/// We care about checking this rather than inserting a sync before all returns regardless of the presence of detach
+/// because we don't want to break tests that depend on MIR or LLVM IR looking a certain way.
+pub fn body_contains_detach<'a, 'tcx>(body: &'a mir::Body<'tcx>) -> bool {
+    body.basic_blocks.iter().any(|bb| {
+        matches!(bb.terminator(), mir::Terminator { kind: mir::TerminatorKind::Detach { .. }, .. })
+    })
+}
+
+pub struct InsertSyncs;
+
+impl<'tcx> MirPass<'tcx> for InsertSyncs {
+    fn run_pass(&self, _tcx: TyCtxt<'_>, body: &mut mir::Body<'tcx>) {
+        trace!("Running InsertSyncs on {:?}", body.source);
+        if !body_contains_detach(body) {
+            return;
+        }
+
+        trace!("Found detach in {:?}, inserting syncs", body.source);
+        let mut new_blocks = body.basic_blocks.clone();
+        // Now that we know this is the case, we want to make a basic block before every return terminator.
+        body.basic_blocks.iter_enumerated().for_each(|(bb, bb_data)| {
+            if let mir::TerminatorKind::Return = bb_data.terminator().kind {
+                // First, we have to create a new block to return instead. Then, we need this block to end in a sync
+                // that leads to the returning block.
+                let return_block = mir::BasicBlockData {
+                    statements: vec![],
+                    terminator: Some(mir::Terminator {
+                        source_info: bb_data.terminator().source_info,
+                        kind: mir::TerminatorKind::Return,
+                    }),
+                    is_cleanup: false,
+                };
+                let target = new_blocks.as_mut().push(return_block);
+                let new_bb_data =
+                    new_blocks.as_mut().get_mut(bb).expect("block should exist in cloned blocks!");
+                new_bb_data.terminator_mut().kind = mir::TerminatorKind::Sync { target };
+            }
+        });
+
+        // Now we finalize our changes by replacing the basic blocks with the new ones that sync before returning.
+        body.basic_blocks = new_blocks;
+    }
+}

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -51,6 +51,7 @@ mod abort_unwinding_calls;
 mod add_call_guards;
 mod add_moves_for_packed_drops;
 mod add_retag;
+mod automatic_sync_insertion;
 mod check_const_item_mutation;
 mod check_packed_ref;
 pub mod check_unsafety;
@@ -546,6 +547,9 @@ fn run_runtime_cleanup_passes<'tcx>(tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
         &lower_intrinsics::LowerIntrinsics,
         &remove_place_mention::RemovePlaceMention,
         &simplify::SimplifyCfg::ElaborateDrops,
+        // NOTE(jhilton): this might not be the best place to insert syncs: we could also do it while lowering
+        // analysis to runtime MIR.
+        &automatic_sync_insertion::InsertSyncs,
     ];
 
     pm::run_passes(tcx, body, passes, Some(MirPhase::Runtime(RuntimePhase::PostCleanup)));

--- a/tests/mir-opt/cilk/implicit_return.fn0.InsertSyncs.diff
+++ b/tests/mir-opt/cilk/implicit_return.fn0.InsertSyncs.diff
@@ -1,0 +1,34 @@
+- // MIR for `fn0` before InsertSyncs
++ // MIR for `fn0` after InsertSyncs
+  
+  fn fn0() -> bool {
+      let mut _0: bool;
+      let mut _1: i32;
+      let mut _2: i32;
+      scope 1 {
+      }
+  
+      bb0: {
+          StorageLive(_1);
+          detach -> [spawned_task: bb1, continuation: bb2];
+      }
+  
+      bb1: {
+          StorageLive(_2);
+          _2 = const 0_i32;
+          _1 = move _2;
+          reattach -> bb2;
+      }
+  
+      bb2: {
+          StorageDead(_2);
+          StorageDead(_1);
+          _0 = const true;
++         sync -> bb3;
++     }
++ 
++     bb3: {
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/cilk/implicit_return.rs
+++ b/tests/mir-opt/cilk/implicit_return.rs
@@ -1,0 +1,17 @@
+#![feature(cilk)]
+// unit-test: InsertSyncs
+
+// compile-flags: -C panic=abort
+// no-prefer-dynamic
+
+// skip-filecheck
+
+// EMIT_MIR implicit_return.fn0.InsertSyncs.diff
+pub fn fn0() -> bool {
+    let _ = cilk_spawn { 0 };
+    true
+}
+
+pub fn main() {
+    println!("{}", fn0());
+}

--- a/tests/mir-opt/cilk/inserts_syncs_for_trailing_if.fn0.InsertSyncs.diff
+++ b/tests/mir-opt/cilk/inserts_syncs_for_trailing_if.fn0.InsertSyncs.diff
@@ -1,0 +1,52 @@
+- // MIR for `fn0` before InsertSyncs
++ // MIR for `fn0` after InsertSyncs
+  
+  fn fn0(_1: bool) -> usize {
+      debug x => _1;
+      let mut _0: usize;
+      let mut _2: i32;
+      let mut _3: i32;
+      let mut _4: bool;
+      scope 1 {
+      }
+  
+      bb0: {
+          StorageLive(_2);
+          detach -> [spawned_task: bb1, continuation: bb2];
+      }
+  
+      bb1: {
+          StorageLive(_3);
+          _3 = const 0_i32;
+          _2 = move _3;
+          reattach -> bb2;
+      }
+  
+      bb2: {
+          StorageDead(_3);
+          StorageDead(_2);
+          StorageLive(_4);
+          _4 = _1;
+          switchInt(move _4) -> [0: bb4, otherwise: bb3];
+      }
+  
+      bb3: {
+          _0 = const 1_usize;
+          goto -> bb5;
+      }
+  
+      bb4: {
+          _0 = const 2_usize;
+          goto -> bb5;
+      }
+  
+      bb5: {
+          StorageDead(_4);
++         sync -> bb6;
++     }
++ 
++     bb6: {
+          return;
+      }
+  }
+  

--- a/tests/mir-opt/cilk/inserts_syncs_for_trailing_if.rs
+++ b/tests/mir-opt/cilk/inserts_syncs_for_trailing_if.rs
@@ -1,0 +1,21 @@
+#![feature(cilk)]
+// unit-test: InsertSyncs
+
+// compile-flags: -C panic=abort
+// no-prefer-dynamic
+
+// skip-filecheck
+
+// EMIT_MIR inserts_syncs_for_trailing_if.fn0.InsertSyncs.diff
+pub fn fn0(x: bool) -> usize {
+    let _ = cilk_spawn { 0 };
+    if x {
+        1
+    } else {
+        2
+    }
+}
+
+pub fn main() {
+    println!("{}", fn0(true));
+}


### PR DESCRIPTION
We implement a MIR pass that performs automatic sync insertion within function bodies. This pass is scheduled after drop elaboration but before optimization passes to ensure that the pass always runs before lowering to LLVM IR, since the OpenCilk runtime expects function bodies to sync before returning.

Automatic sync insertion is implemented by first detecting if a body contains any detaches, in which case we know that we have to sync before return points. Then, for each return terminator, the return terminator is replaced by a sync terminator that jumps to a block which will return instead.