### PR TITLE
Add support for Linux targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ See https://www.rust-lang.org/community for a list of chat platforms and forums.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).
 
+## Required Environment Variables
+The compiler uses the environment variables *OPENCILK_ABI_PATH* and *OPENCILK_RT_SEARCH_DIR*. 
+Although bootstrapping the compiler does not require setting either of these above environment variables, 
+invoking its test suite with "./x test" will. After bootstrapping, running a command like find build -name "libopencilk*" 
+should give both the directory containing the OpenCilk runtime shared library and the path to the bitcode file (a filename which ends in .bc). 
+OPENCILK_ABI_PATH should be set to the path to the bitcode file, and 
+OPENCILK_RT_SEARCH_DIR should be set to the directory containing the runtime's shared library. 
+Exporting these variables in some file like .bashrc or .zshrc should make this requirement less tedious to accommodate 
+until some changes to make rustc search for the OpenCilk runtime shared library and the correct bitcode file are done.
+
 ## License
 
 Rust is primarily distributed under the terms of both the MIT license and the

--- a/compiler/rustc_session/src/config.rs
+++ b/compiler/rustc_session/src/config.rs
@@ -2828,6 +2828,11 @@ pub fn build_session_options(early_dcx: &mut EarlyDiagCtxt, matches: &getopts::M
         search_paths.push(SearchPath::from_cli_opt(early_dcx, s));
     }
 
+    let opencilk_rt_path =
+        std::env::var("OPENCILK_RT_SEARCH_DIR").expect("OPENCILK_RT_SEARCH_DIR must be set");
+    let opencilk_rt_path = Path::new(&opencilk_rt_path);
+    search_paths.push(SearchPath::from_opencilk_runtime_path(opencilk_rt_path));
+
     let libs = parse_libs(early_dcx, matches);
 
     let test = matches.opt_present("test");

--- a/compiler/rustc_session/src/search_paths.rs
+++ b/compiler/rustc_session/src/search_paths.rs
@@ -72,6 +72,10 @@ impl SearchPath {
         Self::new(PathKind::All, make_target_lib_path(sysroot, triple))
     }
 
+    pub fn from_opencilk_runtime_path(opencilk_rt_path: &Path) -> Self {
+        Self::new(PathKind::Native, opencilk_rt_path.to_path_buf())
+    }
+
     fn new(kind: PathKind, dir: PathBuf) -> Self {
         // Get the files within the directory.
         let files = match std::fs::read_dir(&dir) {

--- a/compiler/rustc_target/src/spec/targets/aarch64_apple_darwin.rs
+++ b/compiler/rustc_target/src/spec/targets/aarch64_apple_darwin.rs
@@ -1,16 +1,5 @@
-use std::path::PathBuf;
-
 use crate::spec::base::apple::{macos_llvm_target, opts, Arch};
-use crate::spec::{Cc, FramePointer, LinkerFlavor, Lld, SanitizerSet, Target, TargetOptions};
-
-// Read the environment variable OPENCILK_RT_SEARCH_DIR to get the path to the OpenCilk runtime for
-// this target.
-// FIXME(jhilton): we should have default search paths for this so that we don't need to bother with
-// having users set an environment variable.
-fn opencilk_runtime_search_directory() -> PathBuf {
-    let path = std::env::var("OPENCILK_RT_SEARCH_DIR").expect("OPENCILK_RT_SEARCH_DIR must be set");
-    PathBuf::from(path)
-}
+use crate::spec::{FramePointer, SanitizerSet, Target, TargetOptions};
 
 pub fn target() -> Target {
     let arch = Arch::Arm64;
@@ -21,19 +10,6 @@ pub fn target() -> Target {
     // FIXME: The leak sanitizer currently fails the tests, see #88132.
     base.supported_sanitizers = SanitizerSet::ADDRESS | SanitizerSet::CFI | SanitizerSet::THREAD;
 
-    let mut late_link_args = std::collections::BTreeMap::new();
-    let opencilk_runtime_path = opencilk_runtime_search_directory()
-        .into_os_string()
-        .into_string()
-        .expect("OpenCilk runtime path should contain only valid unicode!");
-    let set_rpath = format!("-Wl,-rpath,{}", opencilk_runtime_path);
-    let args_to_link_opencilk: Vec<std::borrow::Cow<'static, str>> = vec![
-        "-L".into(),
-        opencilk_runtime_path.into(),
-        "-lopencilk_osx_dynamic".into(),
-        set_rpath.into(),
-    ];
-    late_link_args.insert(LinkerFlavor::Darwin(Cc::Yes, Lld::No), args_to_link_opencilk.clone());
     Target {
         // Clang automatically chooses a more specific target based on
         // MACOSX_DEPLOYMENT_TARGET. To enable cross-language LTO to work
@@ -45,7 +21,6 @@ pub fn target() -> Target {
         options: TargetOptions {
             mcount: "\u{1}mcount".into(),
             frame_pointer: FramePointer::NonLeaf,
-            late_link_args,
             ..base
         },
     }


### PR DESCRIPTION
This PR adds support for non-MacOS targets in a way that is target-agnostic. It links the OpenCilk runtime as a required step during code generation rather than using target-specific linker arguments. Additionally, it modifies the search paths for static libraries to include the OpenCilk runtime search directory so `libopencilk` can be found. It also works for statically linked binaries by choosing the correct linking strategy for OpenCilk based on whether static or dynamic linking is requested.

This PR additionally updates the README to reference the required environment variables to get running the test suite to work.