### PR TITLE
Implement cilk_scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ Session.vim
 .idea
 *.iml
 .vscode
+.zed
 .project
 .favorites.json
 .settings/

--- a/compiler/rustc_ast/src/ast.rs
+++ b/compiler/rustc_ast/src/ast.rs
@@ -1298,6 +1298,7 @@ impl Expr {
             ExprKind::Become(..) => ExprPrecedence::Become,
             ExprKind::CilkSpawn(..) => ExprPrecedence::CilkSpawn,
             ExprKind::CilkSync => ExprPrecedence::CilkSync,
+            ExprKind::CilkScope(..) => ExprPrecedence::CilkScope,
             ExprKind::Err => ExprPrecedence::Err,
         }
     }
@@ -1456,6 +1457,9 @@ pub enum ExprKind {
     /// A cilk_spawn block (`cilk_spawn { ... }`).
     // FIXME(jhilton): we might be able to generalize this by making this accept a P<Expr> instead.
     CilkSpawn(P<Block>),
+
+    /// A cilk_scope block (`cilk_scope { ... }`).
+    CilkScope(P<Block>),
 
     /// An assignment (`a = foo()`).
     /// The `Span` argument is the span of the `=` token.

--- a/compiler/rustc_ast/src/mut_visit.rs
+++ b/compiler/rustc_ast/src/mut_visit.rs
@@ -1522,6 +1522,7 @@ pub fn noop_visit_expr<T: MutVisitor>(
         ExprKind::Try(expr) => vis.visit_expr(expr),
         ExprKind::TryBlock(body) => vis.visit_block(body),
         ExprKind::CilkSpawn(body) => vis.visit_block(body),
+        ExprKind::CilkScope(body) => vis.visit_block(body),
         ExprKind::Lit(_) | ExprKind::IncludedBytes(..) | ExprKind::CilkSync | ExprKind::Err => {}
     }
     vis.visit_id(id);

--- a/compiler/rustc_ast/src/util/classify.rs
+++ b/compiler/rustc_ast/src/util/classify.rs
@@ -58,6 +58,7 @@ pub fn expr_trailing_brace(mut expr: &ast::Expr) -> Option<&ast::Expr> {
             | TryBlock(..)
             | While(..)
             | CilkSpawn(..)
+            | CilkScope(..)
             | ConstBlock(_) => break Some(expr),
 
             MacCall(mac) => {

--- a/compiler/rustc_ast/src/util/parser.rs
+++ b/compiler/rustc_ast/src/util/parser.rs
@@ -284,6 +284,7 @@ pub enum ExprPrecedence {
     Loop,
     Match,
     CilkSpawn,
+    CilkScope,
     ConstBlock,
     Block,
     TryBlock,
@@ -353,6 +354,7 @@ impl ExprPrecedence {
             | ExprPrecedence::Loop
             | ExprPrecedence::Match
             | ExprPrecedence::CilkSpawn
+            | ExprPrecedence::CilkScope
             | ExprPrecedence::ConstBlock
             | ExprPrecedence::Block
             | ExprPrecedence::TryBlock

--- a/compiler/rustc_ast/src/visit.rs
+++ b/compiler/rustc_ast/src/visit.rs
@@ -955,6 +955,7 @@ pub fn walk_expr<'a, V: Visitor<'a>>(visitor: &mut V, expression: &'a Expr) {
         ExprKind::Try(subexpression) => visitor.visit_expr(subexpression),
         ExprKind::TryBlock(body) => visitor.visit_block(body),
         ExprKind::CilkSpawn(body) => visitor.visit_block(body),
+        ExprKind::CilkScope(body) => visitor.visit_block(body),
         ExprKind::Lit(_) | ExprKind::IncludedBytes(..) | ExprKind::CilkSync | ExprKind::Err => {}
     }
 

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -297,7 +297,7 @@ impl<'hir> LoweringContext<'_, 'hir> {
                 }
                 ExprKind::CilkScope(body) => {
                     let block = self.lower_block(body, false);
-                    hir::ExprKind::Block(self.arena.alloc(block), None)
+                    hir::ExprKind::CilkScope(self.arena.alloc(block))
                 }
                 ExprKind::CilkSync => hir::ExprKind::CilkSync,
                 ExprKind::InlineAsm(asm) => {

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -296,7 +296,6 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     hir::ExprKind::CilkSpawn(self.arena.alloc(expr))
                 }
                 ExprKind::CilkScope(body) => {
-                    // FIXME(jhilton): here we should be actually lowering to a certain kind of HIR node.
                     let block = self.lower_block(body, false);
                     hir::ExprKind::Block(self.arena.alloc(block), None)
                 }

--- a/compiler/rustc_ast_lowering/src/expr.rs
+++ b/compiler/rustc_ast_lowering/src/expr.rs
@@ -295,6 +295,11 @@ impl<'hir> LoweringContext<'_, 'hir> {
                     let expr = self.expr_block(block);
                     hir::ExprKind::CilkSpawn(self.arena.alloc(expr))
                 }
+                ExprKind::CilkScope(body) => {
+                    // FIXME(jhilton): here we should be actually lowering to a certain kind of HIR node.
+                    let block = self.lower_block(body, false);
+                    hir::ExprKind::Block(self.arena.alloc(block), None)
+                }
                 ExprKind::CilkSync => hir::ExprKind::CilkSync,
                 ExprKind::InlineAsm(asm) => {
                     hir::ExprKind::InlineAsm(self.lower_inline_asm(e.span, asm))

--- a/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
+++ b/compiler/rustc_ast_pretty/src/pprust/state/expr.rs
@@ -820,6 +820,12 @@ impl<'a> State<'a> {
                 self.word_nbsp("cilk_spawn");
                 self.print_block_with_attrs(body, attrs);
             }
+            ast::ExprKind::CilkScope(body) => {
+                self.cbox(0);
+                self.ibox(0);
+                self.word_nbsp("cilk_scope");
+                self.print_block_with_attrs(body, attrs);
+            }
             ast::ExprKind::CilkSync => {
                 self.word("cilk_sync");
             }

--- a/compiler/rustc_borrowck/src/lib.rs
+++ b/compiler/rustc_borrowck/src/lib.rs
@@ -628,7 +628,10 @@ impl<'cx, 'tcx, R> rustc_mir_dataflow::ResultsVisitor<'cx, 'tcx, R> for MirBorro
                 NonDivergingIntrinsic::CopyNonOverlapping(..) => span_bug!(
                     span,
                     "Unexpected CopyNonOverlapping, should only appear after lower_intrinsics",
-                )
+                ),
+                // We expect this before lower_intrinsics (it's emitted directly by MIR lowering)
+                // but the borrow checker doesn't care.
+                NonDivergingIntrinsic::TapirRuntimeStart | NonDivergingIntrinsic::TapirRuntimeStop => {}
             }
             // Only relevant for mir typeck
             StatementKind::AscribeUserType(..)

--- a/compiler/rustc_borrowck/src/polonius/loan_invalidations.rs
+++ b/compiler/rustc_borrowck/src/polonius/loan_invalidations.rs
@@ -62,6 +62,8 @@ impl<'cx, 'tcx> Visitor<'tcx> for LoanInvalidationsGenerator<'cx, 'tcx> {
                 self.consume_operand(location, dst);
                 self.consume_operand(location, count);
             }
+            // Only relevant for hinting when to start the runtime, for which we need something to lower to LLVM IR.
+            StatementKind::Intrinsic(box NonDivergingIntrinsic::TapirRuntimeStart) | StatementKind::Intrinsic(box NonDivergingIntrinsic::TapirRuntimeStop) => {}
             // Only relevant for mir typeck
             StatementKind::AscribeUserType(..)
             // Only relevant for liveness and unsafeck

--- a/compiler/rustc_borrowck/src/type_check/mod.rs
+++ b/compiler/rustc_borrowck/src/type_check/mod.rs
@@ -1369,6 +1369,7 @@ impl<'a, 'tcx> TypeChecker<'a, 'tcx> {
                     stmt.source_info.span,
                     "Unexpected NonDivergingIntrinsic::CopyNonOverlapping, should only appear after lowering_intrinsics",
                 ),
+                NonDivergingIntrinsic::TapirRuntimeStart | NonDivergingIntrinsic::TapirRuntimeStop => {}
             },
             StatementKind::FakeRead(..)
             | StatementKind::StorageLive(..)

--- a/compiler/rustc_builtin_macros/src/assert/context.rs
+++ b/compiler/rustc_builtin_macros/src/assert/context.rs
@@ -322,6 +322,13 @@ impl<'cx, 'a> Context<'cx, 'a> {
             | ExprKind::Become(_)
             // We don't bother supporting nice asserts for cilk_spawn because we don't add an implicit sync or anything.
             | ExprKind::CilkSpawn(_)
+            // FIXME(jhilton): We don't bother supporting nice asserts for cilk_scope because it's hard to determine what it should
+            // evaluate to, so instead it evaluates to None. I'll pick a better design where it actually evaluates to the trailing
+            // value if possible, but then it's questionable where the sync should be inserted. Under this design the sync would be
+            // inserted before the "last expression", which might clearly mean something since the last value in a block has to be
+            // not the result of a spawn to actually be used, which means that all spawns have to be before the trailing value?
+            // This might be easiest to figure out when lowering a cilk_scope to MIR, which is also where the analysis would warn.
+            | ExprKind::CilkScope(..)
             // We don't bother supporting nice asserts for cilk_sync because it always evaluates to unit.
             | ExprKind::CilkSync
             | ExprKind::Yield(_) => {}

--- a/compiler/rustc_builtin_macros/src/assert/context.rs
+++ b/compiler/rustc_builtin_macros/src/assert/context.rs
@@ -322,12 +322,9 @@ impl<'cx, 'a> Context<'cx, 'a> {
             | ExprKind::Become(_)
             // We don't bother supporting nice asserts for cilk_spawn because we don't add an implicit sync or anything.
             | ExprKind::CilkSpawn(_)
-            // FIXME(jhilton): We don't bother supporting nice asserts for cilk_scope because it's hard to determine what it should
-            // evaluate to, so instead it evaluates to None. I'll pick a better design where it actually evaluates to the trailing
-            // value if possible, but then it's questionable where the sync should be inserted. Under this design the sync would be
-            // inserted before the "last expression", which might clearly mean something since the last value in a block has to be
-            // not the result of a spawn to actually be used, which means that all spawns have to be before the trailing value?
-            // This might be easiest to figure out when lowering a cilk_scope to MIR, which is also where the analysis would warn.
+            // FIXME(jhilton): we don't bother supporting nice asserts for cilk_scope right now, but we should, since
+            // cilk_scope does evaluate to a useful type and will compile as long as the trailing expression doesn't
+            // depend on un-synced work.
             | ExprKind::CilkScope(..)
             // We don't bother supporting nice asserts for cilk_sync because it always evaluates to unit.
             | ExprKind::CilkSync

--- a/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
+++ b/compiler/rustc_codegen_gcc/src/intrinsic/mod.rs
@@ -418,6 +418,18 @@ impl<'a, 'gcc, 'tcx> IntrinsicCallMethods<'tcx> for Builder<'a, 'gcc, 'tcx> {
     fn va_end(&mut self, _va_list: RValue<'gcc>) -> RValue<'gcc> {
         unimplemented!();
     }
+
+    fn sync_region_start(&mut self) -> RValue<'gcc> {
+        unimplemented!();
+    }
+
+    fn tapir_runtime_start(&mut self) -> RValue<'gcc> {
+        unimplemented!();
+    }
+
+    fn tapir_runtime_stop(&mut self, token: RValue<'gcc>) {
+        unimplemented!()
+    }
 }
 
 impl<'a, 'gcc, 'tcx> ArgAbiMethods<'tcx> for Builder<'a, 'gcc, 'tcx> {

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -948,8 +948,8 @@ impl<'ll> CodegenCx<'ll, '_> {
         ifn!("llvm.ptrmask", fn(ptr, t_isize) -> ptr);
 
         ifn!("llvm.syncregion.start", fn() -> t_token);
-        ifn!("tapir.runtime.start", fn() -> t_token);
-        ifn!("tapir.runtime.stop", fn(t_token) -> void);
+        ifn!("llvm.tapir.runtime.start", fn() -> t_token);
+        ifn!("llvm.tapir.runtime.stop", fn(t_token) -> void);
 
         None
     }

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -949,7 +949,7 @@ impl<'ll> CodegenCx<'ll, '_> {
 
         ifn!("llvm.syncregion.start", fn() -> t_token);
         ifn!("llvm.tapir.runtime.start", fn() -> t_token);
-        ifn!("llvm.tapir.runtime.stop", fn(t_token) -> void);
+        ifn!("llvm.tapir.runtime.end", fn(t_token) -> void);
 
         None
     }

--- a/compiler/rustc_codegen_llvm/src/context.rs
+++ b/compiler/rustc_codegen_llvm/src/context.rs
@@ -948,6 +948,8 @@ impl<'ll> CodegenCx<'ll, '_> {
         ifn!("llvm.ptrmask", fn(ptr, t_isize) -> ptr);
 
         ifn!("llvm.syncregion.start", fn() -> t_token);
+        ifn!("tapir.runtime.start", fn() -> t_token);
+        ifn!("tapir.runtime.stop", fn(t_token) -> void);
 
         None
     }

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -458,12 +458,12 @@ impl<'ll, 'tcx> IntrinsicCallMethods<'tcx> for Builder<'_, 'll, 'tcx> {
     }
 
     fn tapir_runtime_start(&mut self) -> &'ll Value {
-       self.call_intrinsic("tapir.runtime.start", &[])
+        self.call_intrinsic("llvm.tapir.runtime.start", &[])
     }
 
     fn tapir_runtime_stop(&mut self, token: &'ll Value) {
         // This intrinsic should return void anyways.
-        self.call_intrinsic("tapir.runtime.stop", &[token]);
+        self.call_intrinsic("llvm.tapir.runtime.stop", &[token]);
     }
 }
 

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -459,9 +459,9 @@ impl<'ll, 'tcx> IntrinsicCallMethods<'tcx> for Builder<'_, 'll, 'tcx> {
         self.call_intrinsic("llvm.tapir.runtime.start", &[])
     }
 
-    fn tapir_runtime_stop(&mut self, token: &'ll Value) {
+    fn tapir_runtime_end(&mut self, token: &'ll Value) {
         // This intrinsic should return void anyways.
-        self.call_intrinsic("llvm.tapir.runtime.stop", &[token]);
+        self.call_intrinsic("llvm.tapir.runtime.end", &[token]);
     }
 }
 

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -453,8 +453,17 @@ impl<'ll, 'tcx> IntrinsicCallMethods<'tcx> for Builder<'_, 'll, 'tcx> {
         self.call_intrinsic("llvm.va_end", &[va_list])
     }
 
-    fn sync_region_start(&mut self) -> Self::Value {
+    fn sync_region_start(&mut self) -> &'ll Value {
         self.call_intrinsic("llvm.syncregion.start", &[])
+    }
+
+    fn tapir_runtime_start(&mut self) -> &'ll Value {
+       self.call_intrinsic("tapir.runtime.start", &[])
+    }
+
+    fn tapir_runtime_stop(&mut self, token: &'ll Value) {
+        // This intrinsic should return void anyways.
+        self.call_intrinsic("tapir.runtime.stop", &[token]);
     }
 }
 

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -73,8 +73,6 @@ fn get_simple_intrinsic<'ll>(
         sym::ptr_mask => "llvm.ptrmask",
         sym::roundevenf32 => "llvm.roundeven.f32",
         sym::roundevenf64 => "llvm.roundeven.f64",
-        // We need sync regions to generate Tapir IR.
-        sym::sync_region_start => "llvm.syncregion.start",
         _ => return None,
     };
     Some(cx.get_intrinsic(llvm_name))

--- a/compiler/rustc_codegen_ssa/src/mir/statement.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/statement.rs
@@ -102,7 +102,7 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                         .runtime_hint_stack
                         .pop()
                         .expect("should always hint starting runtime before stopping it!");
-                    bx.tapir_runtime_stop(token);
+                    bx.tapir_runtime_end(token);
                 }
             }
             mir::StatementKind::FakeRead(..)

--- a/compiler/rustc_codegen_ssa/src/mir/statement.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/statement.rs
@@ -91,12 +91,19 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 bx.memcpy(dst, align, src, align, bytes, crate::MemFlags::empty());
             }
             mir::StatementKind::Intrinsic(box NonDivergingIntrinsic::TapirRuntimeStart) => {
-                let token = bx.tapir_runtime_start();
-                self.runtime_hint_stack.push(token);
+                if Bx::supports_tapir() {
+                    let token = bx.tapir_runtime_start();
+                    self.runtime_hint_stack.push(token);
+                }
             }
             mir::StatementKind::Intrinsic(box NonDivergingIntrinsic::TapirRuntimeStop) => {
-                let token = self.runtime_hint_stack.pop().expect("should always hint starting runtime before stopping it!");
-                bx.tapir_runtime_stop(token);
+                if Bx::supports_tapir() {
+                    let token = self
+                        .runtime_hint_stack
+                        .pop()
+                        .expect("should always hint starting runtime before stopping it!");
+                    bx.tapir_runtime_stop(token);
+                }
             }
             mir::StatementKind::FakeRead(..)
             | mir::StatementKind::Retag { .. }

--- a/compiler/rustc_codegen_ssa/src/mir/statement.rs
+++ b/compiler/rustc_codegen_ssa/src/mir/statement.rs
@@ -90,6 +90,14 @@ impl<'a, 'tcx, Bx: BuilderMethods<'a, 'tcx>> FunctionCx<'a, 'tcx, Bx> {
                 let src = src_val.immediate();
                 bx.memcpy(dst, align, src, align, bytes, crate::MemFlags::empty());
             }
+            mir::StatementKind::Intrinsic(box NonDivergingIntrinsic::TapirRuntimeStart) => {
+                let token = bx.tapir_runtime_start();
+                self.runtime_hint_stack.push(token);
+            }
+            mir::StatementKind::Intrinsic(box NonDivergingIntrinsic::TapirRuntimeStop) => {
+                let token = self.runtime_hint_stack.pop().expect("should always hint starting runtime before stopping it!");
+                bx.tapir_runtime_stop(token);
+            }
             mir::StatementKind::FakeRead(..)
             | mir::StatementKind::Retag { .. }
             | mir::StatementKind::AscribeUserType(..)

--- a/compiler/rustc_codegen_ssa/src/traits/intrinsic.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/intrinsic.rs
@@ -37,4 +37,6 @@ pub trait IntrinsicCallMethods<'tcx>: BackendTypes {
     /// Rust defined C-variadic functions return.
     fn va_end(&mut self, val: Self::Value) -> Self::Value;
     fn sync_region_start(&mut self) -> Self::Value;
+    fn tapir_runtime_start(&mut self) -> Self::Value;
+    fn tapir_runtime_stop(&mut self, token: Self::Value);
 }

--- a/compiler/rustc_codegen_ssa/src/traits/intrinsic.rs
+++ b/compiler/rustc_codegen_ssa/src/traits/intrinsic.rs
@@ -38,5 +38,5 @@ pub trait IntrinsicCallMethods<'tcx>: BackendTypes {
     fn va_end(&mut self, val: Self::Value) -> Self::Value;
     fn sync_region_start(&mut self) -> Self::Value;
     fn tapir_runtime_start(&mut self) -> Self::Value;
-    fn tapir_runtime_stop(&mut self, token: Self::Value);
+    fn tapir_runtime_end(&mut self, token: Self::Value);
 }

--- a/compiler/rustc_const_eval/src/interpret/intrinsics.rs
+++ b/compiler/rustc_const_eval/src/interpret/intrinsics.rs
@@ -454,6 +454,8 @@ impl<'mir, 'tcx: 'mir, M: Machine<'mir, 'tcx>> InterpCx<'mir, 'tcx, M> {
                 let count = self.eval_operand(count, None)?;
                 self.copy_intrinsic(&src, &dst, &count, /* nonoverlapping */ true)
             }
+            // These are no-ops without a runtime to operate with, and even so they're just hints.
+            NonDivergingIntrinsic::TapirRuntimeStart | NonDivergingIntrinsic::TapirRuntimeStop => Ok(())
         }
     }
 

--- a/compiler/rustc_const_eval/src/transform/validate.rs
+++ b/compiler/rustc_const_eval/src/transform/validate.rs
@@ -1261,6 +1261,9 @@ impl<'a, 'tcx> Visitor<'tcx> for TypeChecker<'a, 'tcx> {
                     self.fail(location, format!("bad arg ({op_cnt_ty:?} != usize)"))
                 }
             }
+            // These hints both have no invariants.
+            StatementKind::Intrinsic(box NonDivergingIntrinsic::TapirRuntimeStart)
+            | StatementKind::Intrinsic(box NonDivergingIntrinsic::TapirRuntimeStop) => {}
             StatementKind::SetDiscriminant { place, .. } => {
                 if self.mir_phase < MirPhase::Runtime(RuntimePhase::Initial) {
                     self.fail(location, "`SetDiscriminant`is not allowed until deaggregation");

--- a/compiler/rustc_hir/src/hir.rs
+++ b/compiler/rustc_hir/src/hir.rs
@@ -1598,6 +1598,7 @@ impl Expr<'_> {
             ExprKind::Repeat(..) => ExprPrecedence::Repeat,
             ExprKind::Yield(..) => ExprPrecedence::Yield,
             ExprKind::CilkSpawn(..) => ExprPrecedence::CilkSpawn,
+            ExprKind::CilkScope(..) => ExprPrecedence::CilkScope,
             ExprKind::CilkSync => ExprPrecedence::CilkSync,
             ExprKind::Err(_) => ExprPrecedence::Err,
         }
@@ -1667,6 +1668,7 @@ impl Expr<'_> {
             | ExprKind::Cast(..)
             | ExprKind::DropTemps(..)
             | ExprKind::CilkSpawn(..)
+            | ExprKind::CilkScope(..)
             | ExprKind::CilkSync
             | ExprKind::Err(_) => false,
         }
@@ -1753,6 +1755,7 @@ impl Expr<'_> {
             | ExprKind::Yield(..)
             | ExprKind::DropTemps(..)
             | ExprKind::CilkSpawn(..)
+            | ExprKind::CilkScope(..)
             | ExprKind::CilkSync
             | ExprKind::Err(_) => true,
         }
@@ -1932,6 +1935,9 @@ pub enum ExprKind<'hir> {
 
     /// An expression that makes the right-hand side potentially parallel with the continuation.
     CilkSpawn(&'hir Expr<'hir>),
+
+    /// An expression that implicitly syncs at the end of the contained block.
+    CilkScope(&'hir Block<'hir>),
 
     /// A suspension point for spawned tasks.
     CilkSync,

--- a/compiler/rustc_hir/src/intravisit.rs
+++ b/compiler/rustc_hir/src/intravisit.rs
@@ -808,6 +808,9 @@ pub fn walk_expr<'v, V: Visitor<'v>>(visitor: &mut V, expression: &'v Expr<'v>) 
         ExprKind::CilkSpawn(expr) => {
             visitor.visit_expr(expr);
         }
+        ExprKind::CilkScope(block) => {
+            visitor.visit_block(block);
+        }
         ExprKind::CilkSync | ExprKind::Lit(_) | ExprKind::Err(_) => {}
     }
 }

--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -342,6 +342,10 @@ language_item_table! {
 
     String,                  sym::String,              string,                     Target::Struct,         GenericRequirement::None;
     CStr,                    sym::CStr,                c_str,                      Target::Struct,         GenericRequirement::None;
+
+    // Some language items related to Tapir lowering. cilk_scope needs the ability to hint that the runtime should start and stop.
+    TapirRuntimeStart,      sym::tapir_runtime_start,  tapir_runtime_start,        Target::Fn,             GenericRequirement::None;
+    TapirRuntimeStop,       sym::tapir_runtime_stop,   tapir_runtime_stop,         Target::Fn,             GenericRequirement::None;
 }
 
 pub enum GenericRequirement {

--- a/compiler/rustc_hir_pretty/src/lib.rs
+++ b/compiler/rustc_hir_pretty/src/lib.rs
@@ -1534,6 +1534,10 @@ impl<'a> State<'a> {
                 self.word_space("cilk_spawn");
                 self.print_expr_maybe_paren(expr, parser::PREC_JUMP);
             }
+            hir::ExprKind::CilkScope(block) => {
+                self.word_space("cilk_scope");
+                self.print_block(block);
+            }
             hir::ExprKind::CilkSync => {
                 self.word("cilk_sync");
             }

--- a/compiler/rustc_hir_typeck/src/expr.rs
+++ b/compiler/rustc_hir_typeck/src/expr.rs
@@ -361,6 +361,7 @@ impl<'a, 'tcx> FnCtxt<'a, 'tcx> {
             }
             ExprKind::Yield(value, _) => self.check_expr_yield(value, expr),
             ExprKind::CilkSpawn(expr) => self.check_expr(expr),
+            ExprKind::CilkScope(block) => self.check_block_with_expected(block, expected),
             ExprKind::CilkSync => Ty::new_unit(tcx),
             hir::ExprKind::Err(guar) => Ty::new_error(tcx, guar),
         }

--- a/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
+++ b/compiler/rustc_hir_typeck/src/expr_use_visitor.rs
@@ -365,7 +365,8 @@ impl<'a, 'tcx> ExprUseVisitor<'a, 'tcx> {
                 self.consume_expr(value);
             }
 
-            hir::ExprKind::CilkSpawn(block) => self.consume_expr(block),
+            hir::ExprKind::CilkSpawn(expr) => self.consume_expr(expr),
+            hir::ExprKind::CilkScope(block) => self.walk_block(block),
         }
     }
 

--- a/compiler/rustc_hir_typeck/src/mem_categorization.rs
+++ b/compiler/rustc_hir_typeck/src/mem_categorization.rs
@@ -375,6 +375,7 @@ impl<'a, 'tcx> MemCategorizationContext<'a, 'tcx> {
             | hir::ExprKind::InlineAsm(..)
             | hir::ExprKind::OffsetOf(..)
             | hir::ExprKind::CilkSpawn(..)
+            | hir::ExprKind::CilkScope(..)
             | hir::ExprKind::CilkSync
             | hir::ExprKind::Err(_) => Ok(self.cat_rvalue(expr.hir_id, expr_ty)),
         }

--- a/compiler/rustc_middle/src/mir/pretty.rs
+++ b/compiler/rustc_middle/src/mir/pretty.rs
@@ -697,6 +697,8 @@ impl Display for NonDivergingIntrinsic<'_> {
             Self::CopyNonOverlapping(CopyNonOverlapping { src, dst, count }) => {
                 write!(f, "copy_nonoverlapping(dst = {dst:?}, src = {src:?}, count = {count:?})")
             }
+            Self::TapirRuntimeStart => write!(f, "tapir_runtime_start()"),
+            Self::TapirRuntimeStop => write!(f, "tapir_runtime_stop()"),
         }
     }
 }

--- a/compiler/rustc_middle/src/mir/syntax.rs
+++ b/compiler/rustc_middle/src/mir/syntax.rs
@@ -444,6 +444,18 @@ pub enum NonDivergingIntrinsic<'tcx> {
     /// **Needs clarification**: Is this typed or not, ie is there a typed load and store involved?
     /// I vaguely remember Ralf saying somewhere that he thought it should not be.
     CopyNonOverlapping(CopyNonOverlapping<'tcx>),
+
+    /// Denotes a call to the intrinsic function `tapir_runtime_start`.
+    ///
+    /// Although one value is returned, it won't be observed by any Rust caller since it's a
+    /// token for use by `tapir_runtime_stop`.
+    TapirRuntimeStart,
+
+   /// Denotes a call to the intrinsic function `tapir_runtime_stop`.
+   ///
+   /// Although one value is accepted as a parameter, it won't be observed by any Rust caller
+   /// since it's a token from `tapir_runtime_start`.
+   TapirRuntimeStop,
 }
 
 /// Describes what kind of retag is to be performed.

--- a/compiler/rustc_middle/src/mir/visit.rs
+++ b/compiler/rustc_middle/src/mir/visit.rs
@@ -443,7 +443,8 @@ macro_rules! make_mir_visitor {
                                 self.visit_operand(src, location);
                                 self.visit_operand(dst, location);
                                 self.visit_operand(count, location);
-                            }
+                            },
+                            NonDivergingIntrinsic::TapirRuntimeStart | NonDivergingIntrinsic::TapirRuntimeStop => {},
                         }
                     }
                     StatementKind::ConstEvalCounter => {}

--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -499,6 +499,9 @@ pub enum ExprKind<'tcx> {
     CilkSpawn {
         computation: ExprId,
     },
+    CilkScope {
+        block: BlockId,
+    },
     // FIXME(jhilton): does the type of CilkSync make sense here? Where does automatic sync insertion belong?
     //  We might have enough info to do it in HIR but most desugaring happens in MIR and we have more dataflow
     //  info there anyways.

--- a/compiler/rustc_middle/src/thir.rs
+++ b/compiler/rustc_middle/src/thir.rs
@@ -502,9 +502,6 @@ pub enum ExprKind<'tcx> {
     CilkScope {
         block: BlockId,
     },
-    // FIXME(jhilton): does the type of CilkSync make sense here? Where does automatic sync insertion belong?
-    //  We might have enough info to do it in HIR but most desugaring happens in MIR and we have more dataflow
-    //  info there anyways.
     CilkSync,
 }
 

--- a/compiler/rustc_middle/src/thir/visit.rs
+++ b/compiler/rustc_middle/src/thir/visit.rs
@@ -169,6 +169,7 @@ pub fn walk_expr<'thir, 'tcx: 'thir, V: Visitor<'thir, 'tcx>>(
         ThreadLocalRef(_) => {}
         Yield { value } => visitor.visit_expr(&visitor.thir()[value]),
         CilkSpawn { computation } => visitor.visit_expr(&visitor.thir()[computation]),
+        CilkScope { block } => visitor.visit_block(&visitor.thir()[block]),
         CilkSync => {}
     }
 }

--- a/compiler/rustc_mir_build/src/build/expr/as_place.rs
+++ b/compiler/rustc_mir_build/src/build/expr/as_place.rs
@@ -555,6 +555,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             | ExprKind::ThreadLocalRef(_)
             | ExprKind::Call { .. }
             | ExprKind::CilkSpawn { .. }
+            | ExprKind::CilkScope { .. }
             | ExprKind::CilkSync => {
                 // these are not places, so we need to make a temporary.
                 debug_assert!(!matches!(Category::of(&expr.kind), Some(Category::Place)));

--- a/compiler/rustc_mir_build/src/build/expr/as_rvalue.rs
+++ b/compiler/rustc_mir_build/src/build/expr/as_rvalue.rs
@@ -539,6 +539,7 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
             | ExprKind::PlaceTypeAscription { .. }
             | ExprKind::ValueTypeAscription { .. }
             | ExprKind::CilkSpawn { .. }
+            | ExprKind::CilkScope { .. }
             | ExprKind::CilkSync => {
                 // these do not have corresponding `Rvalue` variants,
                 // so make an operand and then return that

--- a/compiler/rustc_mir_build/src/build/expr/category.rs
+++ b/compiler/rustc_mir_build/src/build/expr/category.rs
@@ -56,6 +56,7 @@ impl Category {
             | ExprKind::Call { .. }
             | ExprKind::InlineAsm { .. }
             | ExprKind::CilkSpawn { .. }
+            | ExprKind::CilkScope { .. }
             // NOTE(jhilton): I think this makes sense. It doesn't really fit
             // into any of these categories very well though. It's a control flow
             // construct like the other ones that resolve to nonterminating.

--- a/compiler/rustc_mir_build/src/build/expr/into.rs
+++ b/compiler/rustc_mir_build/src/build/expr/into.rs
@@ -588,7 +588,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
 
             ExprKind::CilkScope { block: ast_block } => {
                 // First, give a hint to start the runtime at the beginning of the scope.
-                let start_runtime_kind = StatementKind::Intrinsic(Box::new(NonDivergingIntrinsic::TapirRuntimeStart));
+                let start_runtime_kind =
+                    StatementKind::Intrinsic(Box::new(NonDivergingIntrinsic::TapirRuntimeStart));
                 let start_runtime = Statement { source_info, kind: start_runtime_kind };
                 this.cfg.push(block, start_runtime);
 
@@ -602,7 +603,8 @@ impl<'a, 'tcx> Builder<'a, 'tcx> {
                 block = next_block;
 
                 // Lastly, give a hint to stop the runtime at the end of the scope.
-                let end_runtime_kind = StatementKind::Intrinsic(Box::new(NonDivergingIntrinsic::TapirRuntimeStop));
+                let end_runtime_kind =
+                    StatementKind::Intrinsic(Box::new(NonDivergingIntrinsic::TapirRuntimeStop));
                 let end_runtime = Statement { source_info, kind: end_runtime_kind };
                 this.cfg.push(block, end_runtime);
 

--- a/compiler/rustc_mir_build/src/check_unsafety.rs
+++ b/compiler/rustc_mir_build/src/check_unsafety.rs
@@ -376,6 +376,7 @@ impl<'a, 'tcx> Visitor<'a, 'tcx> for UnsafetyVisitor<'a, 'tcx> {
             | ExprKind::LogicalOp { .. }
             | ExprKind::Use { .. }
             | ExprKind::CilkSpawn { .. }
+            | ExprKind::CilkScope { .. }
             | ExprKind::CilkSync => {
                 // We don't need to save the old value and restore it
                 // because all the place expressions can't have more

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -801,6 +801,10 @@ impl<'tcx> Cx<'tcx> {
             hir::ExprKind::CilkSpawn(expr) => {
                 ExprKind::CilkSpawn { computation: self.mirror_expr(expr) }
             }
+            hir::ExprKind::CilkScope(block) => {
+                // FIXME(jhilton): this should lower to a specific THIR variant instead.
+                ExprKind::Block { block: self.mirror_block(block) }
+            }
             hir::ExprKind::CilkSync => ExprKind::CilkSync,
             hir::ExprKind::Err(_) => unreachable!("cannot lower a `hir::ExprKind::Err` to THIR"),
         };

--- a/compiler/rustc_mir_build/src/thir/cx/expr.rs
+++ b/compiler/rustc_mir_build/src/thir/cx/expr.rs
@@ -802,8 +802,7 @@ impl<'tcx> Cx<'tcx> {
                 ExprKind::CilkSpawn { computation: self.mirror_expr(expr) }
             }
             hir::ExprKind::CilkScope(block) => {
-                // FIXME(jhilton): this should lower to a specific THIR variant instead.
-                ExprKind::Block { block: self.mirror_block(block) }
+                ExprKind::CilkScope { block: self.mirror_block(block) }
             }
             hir::ExprKind::CilkSync => ExprKind::CilkSync,
             hir::ExprKind::Err(_) => unreachable!("cannot lower a `hir::ExprKind::Err` to THIR"),

--- a/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
+++ b/compiler/rustc_mir_build/src/thir/pattern/check_match.rs
@@ -365,7 +365,8 @@ impl<'p, 'tcx> MatchVisitor<'p, 'tcx> {
             | VarRef { .. }
             | ZstLiteral { .. }
             | Yield { .. }
-            | CilkSpawn { .. } => true,
+            | CilkSpawn { .. }
+            | CilkScope { .. } => true,
         }
     }
 

--- a/compiler/rustc_mir_build/src/thir/print.rs
+++ b/compiler/rustc_mir_build/src/thir/print.rs
@@ -544,6 +544,12 @@ impl<'a, 'tcx> ThirPrinter<'a, 'tcx> {
                 self.print_expr(*computation, depth_lvl + 2);
                 print_indented!(self, "}", depth_lvl);
             }
+            CilkScope { block } => {
+                print_indented!(self, "CilkScope {", depth_lvl);
+                print_indented!(self, "block:", depth_lvl + 1);
+                self.print_block(*block, depth_lvl + 2);
+                print_indented!(self, "}", depth_lvl);
+            }
             CilkSync => {
                 print_indented!(self, "CilkSync", depth_lvl);
             }

--- a/compiler/rustc_mir_dataflow/src/value_analysis.rs
+++ b/compiler/rustc_mir_dataflow/src/value_analysis.rs
@@ -136,6 +136,10 @@ pub trait ValueAnalysis<'tcx> {
             }) => {
                 // This statement represents `*dst = *src`, `count` times.
             }
+            // Both of these intrinsics accept no parameters other than tokens,
+            // which we handle during code generation.
+            NonDivergingIntrinsic::TapirRuntimeStart => {}
+            NonDivergingIntrinsic::TapirRuntimeStop => {}
         }
     }
 

--- a/compiler/rustc_mir_transform/src/jump_threading.rs
+++ b/compiler/rustc_mir_transform/src/jump_threading.rs
@@ -338,6 +338,9 @@ impl<'tcx, 'a> TOFinder<'tcx, 'a> {
             | StatementKind::Intrinsic(box NonDivergingIntrinsic::Assume(..))
             // copy_nonoverlapping takes pointers and mutated the pointed-to value.
             | StatementKind::Intrinsic(box NonDivergingIntrinsic::CopyNonOverlapping(..))
+            // Both of these intrinsics store no places.
+            | StatementKind::Intrinsic(box NonDivergingIntrinsic::TapirRuntimeStart)
+            | StatementKind::Intrinsic(box NonDivergingIntrinsic::TapirRuntimeStop)
             | StatementKind::AscribeUserType(..)
             | StatementKind::Coverage(..)
             | StatementKind::FakeRead(..)

--- a/compiler/rustc_passes/src/hir_stats.rs
+++ b/compiler/rustc_passes/src/hir_stats.rs
@@ -322,7 +322,7 @@ impl<'v> hir_visit::Visitor<'v> for StatCollector<'v> {
                 ConstBlock, Array, Call, MethodCall, Tup, Binary, Unary, Lit, Cast, Type,
                 DropTemps, Let, If, Loop, Match, Closure, Block, Assign, AssignOp, Field, Index,
                 Path, AddrOf, Break, Continue, Ret, Become, InlineAsm, OffsetOf, Struct, Repeat,
-                Yield, CilkSpawn, CilkSync, Err
+                Yield, CilkSpawn, CilkScope, CilkSync, Err
             ]
         );
         hir_visit::walk_expr(self, e)

--- a/compiler/rustc_passes/src/hir_stats.rs
+++ b/compiler/rustc_passes/src/hir_stats.rs
@@ -589,7 +589,7 @@ impl<'v> ast_visit::Visitor<'v> for StatCollector<'v> {
                 If, While, ForLoop, Loop, Match, Closure, Block, Await, TryBlock, Assign,
                 AssignOp, Field, Index, Range, Underscore, Path, AddrOf, Break, Continue, Ret,
                 InlineAsm, FormatArgs, OffsetOf, MacCall, Struct, Repeat, Paren, Try, Yield, Yeet,
-                Become, IncludedBytes, Gen, CilkSpawn, CilkSync, Err
+                Become, IncludedBytes, Gen, CilkSpawn, CilkScope, CilkSync, Err
             ]
         );
         ast_visit::walk_expr(self, e)

--- a/compiler/rustc_passes/src/naked_functions.rs
+++ b/compiler/rustc_passes/src/naked_functions.rs
@@ -208,6 +208,7 @@ impl<'tcx> CheckInlineAssembly<'tcx> {
             | ExprKind::Struct(..)
             | ExprKind::Repeat(..)
             | ExprKind::CilkSpawn(..)
+            | ExprKind::CilkScope(..)
             | ExprKind::CilkSync
             | ExprKind::Yield(..) => {
                 self.items.push((ItemKind::NonAsm, span));

--- a/compiler/rustc_smir/src/rustc_smir/convert/mir.rs
+++ b/compiler/rustc_smir/src/rustc_smir/convert/mir.rs
@@ -424,6 +424,11 @@ impl<'tcx> Stable<'tcx> for mir::NonDivergingIntrinsic<'tcx> {
                     count: copy_non_overlapping.count.stable(tables),
                 })
             }
+            NonDivergingIntrinsic::TapirRuntimeStart | NonDivergingIntrinsic::TapirRuntimeStop => {
+                // NOTE(jhilton): for the same reason that we don't include Detach, Reattach, or Sync,
+                // we don't include these intrinsics.
+                unreachable!()
+            }
         }
     }
 }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1641,6 +1641,8 @@ symbols! {
         sync,
         sync_region_start,
         t32,
+        tapir_runtime_start,
+        tapir_runtime_stop,
         target,
         target_abi,
         target_arch,

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -33,6 +33,7 @@ symbols! {
 
         // NOTE(jhilton): do spawn and sync make sense as unstable keywords? At some point they should
         //  probably become stable keywords.
+        //  Same applies to scope here.
 
         // Keywords that are used in stable Rust.
         As:                 "as",
@@ -77,6 +78,7 @@ symbols! {
         Box:                "box",
         CilkSpawn:          "cilk_spawn",
         CilkSync:           "cilk_sync",
+        CilkScope:          "cilk_scope",
         Do:                 "do",
         Final:              "final",
         Macro:              "macro",

--- a/compiler/rustc_ty_utils/messages.ftl
+++ b/compiler/rustc_ty_utils/messages.ftl
@@ -14,6 +14,8 @@ ty_utils_borrow_not_supported = borrowing is not supported in generic constants
 
 ty_utils_box_not_supported = allocations are not allowed in generic constants
 
+ty_utils_cilk_scope_not_supported = cilk_scope is not supported in generic constants
+
 ty_utils_cilk_spawn_not_supported = cilk_spawn is not supported in generic constants
 
 ty_utils_cilk_sync_not_supported = cilk_sync is not supported in generic constants

--- a/compiler/rustc_ty_utils/src/consts.rs
+++ b/compiler/rustc_ty_utils/src/consts.rs
@@ -257,6 +257,9 @@ fn recurse_build<'tcx>(
         ExprKind::CilkSpawn { .. } => {
             error(GenericConstantTooComplexSub::CilkSpawnNotSupported(node.span))?
         }
+        ExprKind::CilkScope { .. } => {
+            error(GenericConstantTooComplexSub::CilkScopeNotSupported(node.span))?
+        }
         ExprKind::CilkSync => error(GenericConstantTooComplexSub::CilkSyncNotSupported(node.span))?,
 
         // we dont permit let stmts so `VarRef` and `UpvarRef` cant happen
@@ -361,6 +364,7 @@ impl<'a, 'tcx> IsThirPolymorphic<'a, 'tcx> {
             | thir::ExprKind::ThreadLocalRef(_)
             | thir::ExprKind::Yield { .. }
             | thir::ExprKind::CilkSpawn { .. }
+            | thir::ExprKind::CilkScope { .. }
             | thir::ExprKind::CilkSync => false,
         }
     }

--- a/compiler/rustc_ty_utils/src/errors.rs
+++ b/compiler/rustc_ty_utils/src/errors.rs
@@ -69,6 +69,8 @@ pub enum GenericConstantTooComplexSub {
     OperationNotSupported(#[primary_span] Span),
     #[label(ty_utils_cilk_spawn_not_supported)]
     CilkSpawnNotSupported(#[primary_span] Span),
+    #[label(ty_utils_cilk_scope_not_supported)]
+    CilkScopeNotSupported(#[primary_span] Span),
     #[label(ty_utils_cilk_sync_not_supported)]
     CilkSyncNotSupported(#[primary_span] Span),
 }

--- a/tests/codegen/cilk/fib.rs
+++ b/tests/codegen/cilk/fib.rs
@@ -1,0 +1,24 @@
+#![feature(cilk)]
+
+// compile-flags: -O -Cpanic=abort -Cno-prepopulate-passes
+// no-prefer-dynamic
+pub fn fib(n: u8) -> usize {
+    if n <= 1 {
+        return n as usize;
+    }
+
+    cilk_scope {
+        // CHECK: tapir.runtime.start
+        // CHECK: detach
+        let x = cilk_spawn { fib(n - 1) };
+        // CHECK: reattach
+        let y = fib(n - 2);
+        cilk_sync;
+        x + y
+    }
+    // CHECK: tapir.runtime.stop
+}
+
+fn main() {
+    assert_eq!(fib(10), 55);
+}

--- a/tests/codegen/cilk/fib.rs
+++ b/tests/codegen/cilk/fib.rs
@@ -8,7 +8,7 @@ pub fn fib(n: u8) -> usize {
     }
 
     cilk_scope {
-        // CHECK: tapir.runtime.start
+        // CHECK: llvm.tapir.runtime.start
         // CHECK: detach
         let x = cilk_spawn { fib(n - 1) };
         // CHECK: reattach
@@ -17,7 +17,7 @@ pub fn fib(n: u8) -> usize {
         cilk_sync;
         x + y
     }
-    // CHECK: tapir.runtime.stop
+    // CHECK: llvm.tapir.runtime.stop
 }
 
 fn main() {

--- a/tests/codegen/cilk/fib.rs
+++ b/tests/codegen/cilk/fib.rs
@@ -13,6 +13,7 @@ pub fn fib(n: u8) -> usize {
         let x = cilk_spawn { fib(n - 1) };
         // CHECK: reattach
         let y = fib(n - 2);
+        // CHECK: sync
         cilk_sync;
         x + y
     }

--- a/tests/mir-opt/cilk/scope_emits_intrinsics.fn0.built.after.mir
+++ b/tests/mir-opt/cilk/scope_emits_intrinsics.fn0.built.after.mir
@@ -1,0 +1,18 @@
+// MIR for `fn0` after built
+
+fn fn0() -> bool {
+    let mut _0: bool;
+    let _1: bool;
+    scope 1 {
+        debug x => _1;
+    }
+
+    bb0: {
+        StorageLive(_1);
+        _1 = const true;
+        FakeRead(ForLet(None), _1);
+        _0 = _1;
+        StorageDead(_1);
+        return;
+    }
+}

--- a/tests/mir-opt/cilk/scope_emits_intrinsics.fn0.built.after.mir
+++ b/tests/mir-opt/cilk/scope_emits_intrinsics.fn0.built.after.mir
@@ -9,7 +9,13 @@ fn fn0() -> bool {
 
     bb0: {
         StorageLive(_1);
+        tapir_runtime_start();
         _1 = const true;
+        sync -> bb1;
+    }
+
+    bb1: {
+        tapir_runtime_stop();
         FakeRead(ForLet(None), _1);
         _0 = _1;
         StorageDead(_1);

--- a/tests/mir-opt/cilk/scope_emits_intrinsics.rs
+++ b/tests/mir-opt/cilk/scope_emits_intrinsics.rs
@@ -8,7 +8,7 @@
 // EMIT_MIR scope_emits_intrinsics.fn0.built.after.mir
 pub fn fn0() -> bool {
     // CHECK: tapir_runtime_start
-    // CHECK: tapir_runtime_end
+    // CHECK: tapir_runtime_stop
     let x = cilk_scope { true };
     x
 }

--- a/tests/mir-opt/cilk/scope_emits_intrinsics.rs
+++ b/tests/mir-opt/cilk/scope_emits_intrinsics.rs
@@ -1,0 +1,14 @@
+#![feature(cilk)]
+// This test checks that cilk_scope emits tapir_runtime_start and tapir_runtime_end
+// intrinsic calls while lowering cilk_scope.
+
+// compile-flags: -C panic=abort
+// no-prefer-dynamic
+
+// EMIT_MIR scope_emits_intrinsics.fn0.built.after.mir
+pub fn fn0() -> bool {
+    // CHECK: tapir_runtime_start
+    // CHECK: tapir_runtime_end
+    let x = cilk_scope { true };
+    x
+}

--- a/tests/ui/cilk/const_scope.rs
+++ b/tests/ui/cilk/const_scope.rs
@@ -1,0 +1,23 @@
+#![feature(cilk)]
+// Tests that cilk_scope can be used in a const context.
+
+// run-pass
+// compile-flags: -C panic=abort
+// no-prefer-dynamic
+
+const fn fib(n: u8) -> usize {
+    if n <= 1 {
+        return n as usize;
+    }
+
+    cilk_scope {
+        let x = cilk_spawn { fib(n - 1) };
+        let y = fib(n - 2);
+        cilk_sync;
+        x + y
+    }
+}
+
+fn main() {
+    assert_eq!(fib(10), 55);
+}

--- a/tests/ui/cilk/scope_can_return_uninit_val.rs
+++ b/tests/ui/cilk/scope_can_return_uninit_val.rs
@@ -1,0 +1,13 @@
+#![feature(cilk)]
+// Tests that scope can return an uninitialized variable.
+
+// build-pass
+// compile-flags: -C panic=abort
+// no-prefer-dynamic
+
+fn main() {
+    let x = cilk_scope {
+        cilk_spawn { 5 }
+    };
+    assert_eq!(x, 5);
+}

--- a/tests/ui/cilk/scope_cannot_use_uninit_vars.rs
+++ b/tests/ui/cilk/scope_cannot_use_uninit_vars.rs
@@ -1,0 +1,22 @@
+#![feature(cilk)]
+// Tests that scope can't return a value resulting from uninitialized variables.
+
+// compile-flags: -C panic=abort
+// no-prefer-dynamic
+
+fn fib(n: u8) -> usize {
+    if n <= 1 {
+        return n as usize;
+    }
+
+    cilk_scope {
+        let x = cilk_spawn { fib(n - 1) };
+        let y = fib(n - 2);
+        x + y
+    //~^ ERROR used binding `x` is possibly-uninitialized [E0381]
+    }
+}
+
+fn main() {
+    assert_eq!(fib(10), 55);
+}

--- a/tests/ui/cilk/scope_cannot_use_uninit_vars.stderr
+++ b/tests/ui/cilk/scope_cannot_use_uninit_vars.stderr
@@ -1,0 +1,14 @@
+error[E0381]: used binding `x` is possibly-uninitialized
+  --> $DIR/scope_cannot_use_uninit_vars.rs:15:9
+   |
+LL |         let x = cilk_spawn { fib(n - 1) };
+   |             -              -------------- binding initialized here in some conditions
+   |             |
+   |             binding declared here but left uninitialized
+LL |         let y = fib(n - 2);
+LL |         x + y
+   |         ^ `x` used here but it is possibly-uninitialized
+
+error: aborting due to 1 previous error
+
+For more information about this error, try `rustc --explain E0381`.

--- a/tests/ui/feature-gates/feature-gate-cilk.rs
+++ b/tests/ui/feature-gates/feature-gate-cilk.rs
@@ -1,4 +1,5 @@
 fn main() {
     cilk_spawn { 5 }; //~ ERROR cilk keywords are experimental [E0658]
     cilk_sync; //~ ERROR cilk keywords are experimental [E0658]
+    cilk_scope { 5 }; //~ ERROR cilk keywords are experimental [E0658]
 }

--- a/tests/ui/feature-gates/feature-gate-cilk.stderr
+++ b/tests/ui/feature-gates/feature-gate-cilk.stderr
@@ -16,6 +16,15 @@ LL |     cilk_sync;
    = help: add `#![feature(cilk)]` to the crate attributes to enable
    = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
 
-error: aborting due to 2 previous errors
+error[E0658]: cilk keywords are experimental
+  --> $DIR/feature-gate-cilk.rs:4:5
+   |
+LL |     cilk_scope { 5 };
+   |     ^^^^^^^^^^
+   |
+   = help: add `#![feature(cilk)]` to the crate attributes to enable
+   = note: this compiler was built on YYYY-MM-DD; consider upgrading it if it is out of date
+
+error: aborting due to 3 previous errors
 
 For more information about this error, try `rustc --explain E0658`.


### PR DESCRIPTION
This PR adds tests and an implementation for the `cilk_scope` keyword in Rust + Cilk. The semantics of the keyword are as follows: `cilk_scope B` evaluates to the same value as `{ let x = B; cilk_sync; B }`, where `B` is a block. The reasons to prefer `cilk_scope` are that it emits hints to the OpenCilk runtime to start and stop only within the scope rather than across the whole function, reducing the cost of initializing runtime data structures on serial code paths. 

`cilk_scope` in Rust + Cilk notably differs from `cilk_scope` in OpenCilk for C and C++ in that it evaluates to a value and, due to existing semantic constraints, the compiler's support for uninitialized variable errors gives warnings when that value is a result of using some possibly-uninitialized variable. Therefore, programmers may need to include a `cilk_sync` in the block within `cilk_scope` to ensure that all values the result depends upon are initialized, whereas in OpenCilk for C and C++, it's more obvious that the implicit sync is at the end of the block. An alternative place to sync in this case is to  sync before the last expression of the block, but this has strange semantics if that last expression additionally contains a `cilk_sync` and the solution chosen here actually mirrors the C/C++ semantics the most closely. It simply appears to be different because, in keeping with Rust's expression-oriented philosophy, `cilk_scope` evaluates to a value rather than unit (void, in C/C++ terms).

An example of one such program which would error is the following:
```
fn fib(n: u8) -> usize {
  if n <= 1 {
    return n;
  }
  
  cilk_scope {
    let x = cilk_spawn { fib(n - 1) };
    let y = fib(n - 2);
    x + y
  }
}
```

Instead, a user would have to write the following:
```
fn fib(n: u8) -> usize {
  if n <= 1 {
    return n;
  }
  
  cilk_scope {
    let x = cilk_spawn { fib(n - 1) };
    let y = fib(n - 2);
    cilk_sync;
    x + y
  }
}
```
The latter version allows the compiler to ensure that `x` has been initialized, since the implicit `cilk_sync` inserted is inserted after the final expression (roughly, after the last line in the `cilk_scope` block). This PR currently does not allow programs which return uninitialized variables as the last expression in a block, since being the last expression in the block is considered a usage of the place (which is disallowed).

Introducing cilk_scope provides a performance improvement in our Fibonacci benchmark. For small values of n, Rust + Cilk is 7-14% slower than OpenCilk, while for large values of n (>= 23), Rust + Cilk is 4-14% faster. Further investigation of the LLVM IR is necessary to determine why this is the case.