### PR TITLE
Fix consume_iter internal compiler error

### DIFF
--- a/compiler/rustc_mir_dataflow/src/task_info.rs
+++ b/compiler/rustc_mir_dataflow/src/task_info.rs
@@ -88,6 +88,7 @@ impl TaskDataBuilder {
 }
 
 /// Whether a task is the root task of the function or a descendant of the root task.
+#[derive(Debug)]
 pub enum TaskKind {
     Root,
     Child { parent: Task, last_location: Location },

--- a/tests/ui/cilk/consume_iter_ice.rs
+++ b/tests/ui/cilk/consume_iter_ice.rs
@@ -1,0 +1,39 @@
+#![feature(cilk)]
+// Reproduces internal compiler error with consume_iter from Rayon code.
+// At some point we would expect this to fail since it has concurrent
+// mutable access to the iterator, so this is marked as known-bug.
+
+// known-bug: unknown
+// compile-flags: -C panic=abort
+// no-prefer-dynamic
+
+struct Ptr<T>(*mut T);
+
+struct Foo<T> {
+    start: Ptr<T>,
+    total_len: usize,
+    initialized_len: usize,
+}
+
+impl<T> Foo<T> {
+    fn consume_iter<I>(mut self, iter: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+    {
+        let mut i = iter.into_iter();
+        for j in 0..self.total_len {
+            cilk_spawn {
+                if let Some(item) = i.next() {
+                    unsafe {
+                        self.start.0.add(j).write(item);
+                        self.initialized_len += 1;
+                    }
+                }
+            }
+        }
+        cilk_sync;
+        self
+    }
+}
+
+fn main() {}


### PR DESCRIPTION
This PR ignores tasks which don't have a known dataflow state at a given last location when iterating over task last locations. This should be correct since the dataflow analysis should see a changed preheader after computing dataflow for the loop body. When the preheader's dataflow state is changed, it should trigger a recomputation of the dataflow state for the sync. When the sync's output dataflow is recomputed, the task last location will now have a known dataflow state which will be incorporated into the sync output.

Loops are the only case I expect this to be a problem (perhaps tail recursion?). However, this should be correct for cases where back-edges reach syncs anyways.

It also adds a regression test for this behavior in future.